### PR TITLE
docs: add alternate installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,17 @@ TabICL processes tabular data through three sequential stages:
 
 ## Installation
 
+### Option 1: Installing `tabicl` from the Local Clone
+
 ```bash
 cd tabicl
 pip install -e .
+```
+
+### Option 2: Installing `tabicl` Directly from the Git Remote
+
+```bash
+pip install git+https://github.com/soda-inria/tabicl.git
 ```
 
 ## Usage


### PR DESCRIPTION
I added a second option to install `tabicl` using the git remote. This could also make it easier for developers who wish to add `tabicl` as part of their dependencies in their project `requirements.txt` or `pyproject.toml`.

Hope this helps!:)