### PR TITLE
Bugfix: Correct offloading for Row and ICL stages

### DIFF
--- a/src/tabicl/sklearn/base.py
+++ b/src/tabicl/sklearn/base.py
@@ -143,8 +143,22 @@ class TabICLBaseEstimator(BaseEstimator):
                 "offload": self.offload_mode,
                 "disk_offload_dir": self.disk_offload_dir,
             },
-            "ROW_CONFIG": {"device": self.device_, "use_amp": use_amp, "use_fa3": use_fa3, "verbose": self.verbose},
-            "ICL_CONFIG": {"device": self.device_, "use_amp": use_amp, "use_fa3": use_fa3, "verbose": self.verbose},
+            "ROW_CONFIG": {
+                "device": self.device_,
+                "use_amp": use_amp,
+                "use_fa3": use_fa3,
+                "verbose": self.verbose,
+                "offload": self.offload_mode,
+                "disk_offload_dir": self.disk_offload_dir,
+            },
+            "ICL_CONFIG": {
+                "device": self.device_,
+                "use_amp": use_amp,
+                "use_fa3": use_fa3,
+                "verbose": self.verbose,
+                "offload": self.offload_mode,
+                "disk_offload_dir": self.disk_offload_dir,
+            },
         }
         if self.inference_config is None:
             self.inference_config_ = InferenceConfig()


### PR DESCRIPTION
## Description
This PR fixes a bug where `offload_mode` and `disk_offload_dir` were not being propagated to `ROW_CONFIG` and `ICL_CONFIG` within `TabICLBaseEstimator`. Those parameters were present in `COL_CONFIG` but not in `ROW_CONFIG` and `ICL_CONFIG`.

## Problem
Previously, the absence of these parameters caused the internal configuration to default to `user_requested` device placement on GPU. This meant that even if a user explicitly requested CPU or disk offloading, the system would attempt to keep tensors on the GPU, leading to Out-Of-Memory (OOM) errors. It was working fine for column embedding stage.

## Solution
Explicitly pass the `offload` and `disk_offload_dir` parameters to the `ROW_CONFIG` and `ICL_CONFIG` dictionaries to ensure offloading preferences are respected across all computation phases.
