### PR TITLE
Preprocessing for numpy arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,14 +241,14 @@ We see good generalization to more columns and don't know where the limit is.
 ## Preprocessing
 
 ### Simple built-in preprocessing
-If the input `X` to TabICL is a pandas DataFrame, TabICL will automatically:
-- Detect and ordinal encode categorical columns (including string, object, category, and boolean types)
+For `X`, TabICL accepts pandas dataframes or numpy arrays.
+It applies the following preprocessing:
+- Detect and ordinal encode categorical columns 
+  (including string, object, category, and boolean types). For numpy arrays,
+  all columns have the same datatype (the one of the array). 
+  Columns with integers are detected as numerical.
 - Create a separate category for missing values in categorical features
 - Perform mean imputation for missing numerical values (encoded as NaN)
-
-If the input `X` is a numpy array, TabICL assumes that ordinal encoding and missing value imputation have already been performed.
-
-For both input types, TabICL applies additional preprocessing:
 - Outlier detection and removal
 - Feature scaling and normalization
 - Feature shuffling for ensemble diversity

--- a/src/tabicl/sklearn/classifier.py
+++ b/src/tabicl/sklearn/classifier.py
@@ -775,3 +775,8 @@ class TabICLClassifier(ClassifierMixin, TabICLBaseEstimator):
         y = np.argmax(proba, axis=1)
 
         return self.y_encoder_.inverse_transform(y)
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.allow_nan = True
+        return tags

--- a/src/tabicl/sklearn/preprocessing.py
+++ b/src/tabicl/sklearn/preprocessing.py
@@ -96,9 +96,18 @@ class TransformToNumerical(TransformerMixin, BaseEstimator):
         self : TransformToNumerical
             Returns self.
         """
+
+        cat_tfm = OrdinalEncoder(
+            dtype=np.int64, handle_unknown="use_encoded_value", unknown_value=-1, encoded_missing_value=-1
+        )
+        num_tfm = SimpleImputer()
+
         if not hasattr(X, "columns"):  # proxy way to check whether X is a dataframe without importing pandas
             # no dataframe
-            self.tfm_ = FunctionTransformer()
+            # check if dtype is bool, object, byte sting, or unicode string
+            is_categorical = np.asarray(X).dtype.kind in {"b", "O", "S", "U"}
+            self.tfm_ = cat_tfm if is_categorical else num_tfm
+            self.tfm_.fit(X)
             return self
 
         cat_cols = make_column_selector(dtype_include=["string", "object", "category", "boolean"])(X)
@@ -108,16 +117,7 @@ class TransformToNumerical(TransformerMixin, BaseEstimator):
         numeric_pos = [X.columns.get_loc(col) for col in numeric_cols]
 
         self.tfm_ = ColumnTransformer(
-            transformers=[
-                (
-                    "categorical",
-                    OrdinalEncoder(
-                        dtype=np.int64, handle_unknown="use_encoded_value", unknown_value=-1, encoded_missing_value=-1
-                    ),
-                    cat_pos,
-                ),
-                ("continuous", SimpleImputer(), numeric_pos),
-            ]
+            transformers=[("categorical", cat_tfm, cat_pos), ("continuous", num_tfm, numeric_pos)]
         )
         self.tfm_.fit(X)
 

--- a/src/tabicl/sklearn/regressor.py
+++ b/src/tabicl/sklearn/regressor.py
@@ -742,3 +742,8 @@ class TabICLRegressor(RegressorMixin, TabICLBaseEstimator):
             return final_results[output_type[0]]
 
         return final_results
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.allow_nan = True
+        return tags

--- a/tests/test_numpy_inputs.py
+++ b/tests/test_numpy_inputs.py
@@ -1,0 +1,90 @@
+import numpy as np
+import pytest
+from sklearn.base import clone, is_classifier
+
+from src.tabicl import TabICLClassifier, TabICLRegressor
+
+
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        TabICLClassifier(random_state=0),
+        TabICLRegressor(random_state=0),
+    ],
+)
+def test_tabicl_supports_nans(estimator):
+    est = clone(estimator)
+
+    X = np.array(
+        [
+            [1.0, np.nan, 3.0],
+            [4.0, 5.0, np.nan],
+            [7.0, 8.0, 9.0],
+            [np.nan, 11.0, 12.0],
+        ],
+        dtype=float,
+    )
+
+    if is_classifier(est):
+        y = np.array([0, 1, 0, 1])
+    else:
+        y = np.array([0.1, 1.2, 2.3, 3.4], dtype=float)
+
+    est.fit(X, y)
+    y_pred = est.predict(X)
+
+    assert y_pred.shape == y.shape
+
+
+@pytest.mark.parametrize(
+    "X",
+    [
+        np.array(
+            [
+                [True, False, True],
+                [False, True, False],
+                [True, True, False],
+                [False, False, True],
+            ],
+            dtype=bool,
+        ),
+        np.array(
+            [
+                [1, 2.5, 3],
+                [4, 5.5, 6],
+                [7, 8.5, 9],
+                [10, 11.5, 12],
+            ],
+            dtype=object,
+        ),
+        np.array(
+            [
+                ["1.0", "2.0", "3.0"],
+                ["4.0", "5.0", "6.0"],
+                ["7.0", "8.0", "9.0"],
+                ["10.0", "11.0", "12.0"],
+            ],
+            dtype=str,
+        ),
+    ],
+    ids=["bool", "object", "string"],
+)
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        TabICLClassifier(random_state=0),
+        TabICLRegressor(random_state=0),
+    ],
+)
+def test_tabicl_supports_bool_object_and_string_inputs(estimator, X):
+    est = clone(estimator)
+
+    if is_classifier(est):
+        y = np.array([0, 1, 0, 1])
+    else:
+        y = np.array([0.1, 1.2, 2.3, 3.4], dtype=float)
+
+    est.fit(X, y)
+    y_pred = est.predict(X)
+
+    assert y_pred.shape == y.shape


### PR DESCRIPTION
Apply imputation or ordinal encoding also to numpy arrays based on dtype. Updated README. Added tests. Added a sklearn tag to say that NaNs are supported to make tests pass.