### PR TITLE
Fix docstring formatting

### DIFF
--- a/src/tabicl/sklearn/classifier.py
+++ b/src/tabicl/sklearn/classifier.py
@@ -232,7 +232,7 @@ class TabICLClassifier(ClassifierMixin, TabICLBaseEstimator):
     n_samples_in_ : int
         Number of samples in the training data.
 
-    feature_names_in_ : ndarray of shape (n_features_in_,) or None
+    feature_names_in_ : ndarray of shape ``(n_features_in_,)`` or None
         Feature names seen during ``fit``. Only set when the input ``X`` has
         feature names (e.g., a pandas DataFrame with string column names).
 

--- a/src/tabicl/sklearn/regressor.py
+++ b/src/tabicl/sklearn/regressor.py
@@ -195,7 +195,7 @@ class TabICLRegressor(RegressorMixin, TabICLBaseEstimator):
     n_samples_in_ : int
         Number of samples in the training data.
 
-    feature_names_in_ : ndarray of shape (n_features_in_,) or None
+    feature_names_in_ : ndarray of shape ``(n_features_in_,)`` or None
         Feature names seen during ``fit``. Only set when the input ``X`` has
         feature names (e.g., a pandas DataFrame with string column names).
 


### PR DESCRIPTION
Fix the following warnings with `make html`:
```
/home/lesteve/dev/tabicl/src/tabicl/sklearn/classifier.py:docstring of tabicl.sklearn.classifier.TabICLClassifier:68: ERROR: Unexpected indentation. [docutils]
/home/lesteve/dev/tabicl/src/tabicl/sklearn/classifier.py:docstring of tabicl.sklearn.classifier.TabICLClassifier:70: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/lesteve/dev/tabicl/src/tabicl/sklearn/classifier.py:docstring of tabicl.sklearn.classifier.TabICLClassifier.fit:9: ERROR: Unexpected indentation. [docutils]
/home/lesteve/dev/tabicl/src/tabicl/sklearn/regressor.py:docstring of tabicl.sklearn.regressor.TabICLRegressor:50: ERROR: Unexpected indentation. [docutils]
/home/lesteve/dev/tabicl/src/tabicl/sklearn/regressor.py:docstring of tabicl.sklearn.regressor.TabICLRegressor:52: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/lesteve/dev/tabicl/src/tabicl/sklearn/regressor.py:docstring of tabicl.sklearn.regressor.TabICLRegressor.predict:18: ERROR: Unexpected indentation. [docutils]
/home/lesteve/dev/tabicl/src/tabicl/sklearn/regressor.py:docstring of tabicl.sklearn.regressor.TabICLRegressor.predict:19: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/lesteve/dev/tabicl/src/tabicl/sklearn/classifier.py:docstring of tabicl.sklearn.classifier.TabICLClassifier:195: ERROR: Unknown target name: "n_features_in". [docutils]
/home/lesteve/dev/tabicl/src/tabicl/sklearn/regressor.py:docstring of tabicl.sklearn.regressor.TabICLRegressor:161: ERROR: Unknown target name: "n_features_in". [docutils]
```

It was causing rendering issues like this where bullet points are not rendered:
<img width="726" height="259" alt="image" src="https://github.com/user-attachments/assets/85e1d4a0-eeb6-4753-a686-156dbe54f41f" />
