### PR TITLE
Fix index title

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,4 @@
+.. title:: TaICL: An Open Tabular Foundation Model
 
 .. raw:: html
 


### PR DESCRIPTION
My sparkle changes have led to having the landing page title be "Installation".
This title is important for search engines.

The present PR fixes this error and control the landing page title