### PR TITLE
CI Set explicit read permissions in workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,8 @@
 name: 'test'
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -24,7 +27,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -50,7 +53,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
See for example [zizmor doc](https://docs.zizmor.sh/audits/#excessive-permissions).

I also bumped `actions/checkout` version while I was at it.