### PR TITLE
feat: add multi-target inference

### DIFF
--- a/src/tabicl/sklearn/classifier.py
+++ b/src/tabicl/sklearn/classifier.py
@@ -270,6 +270,21 @@ class TabICLClassifier(ClassifierMixin, TabICLBaseEstimator):
         Created during ``fit()`` when ``kv_cache`` is enabled. When set,
         ``predict_proba()`` reuses the cached key-value projections instead of
         re-processing training data, enabling faster inference on multiple test sets.
+
+    n_targets_ : int
+        Number of targets. 1 for single-target, >1 for multi-target.
+
+    y_encoders_ : list[LabelEncoder]
+        Per-target label encoders. Only set when ``n_targets_ > 1``.
+
+    classes_list_ : list[ndarray]
+        Per-target class labels. Only set when ``n_targets_ > 1``.
+
+    n_classes_list_ : list[int]
+        Per-target number of classes. Only set when ``n_targets_ > 1``.
+
+    y_train_encoded_ : ndarray of shape (n_samples, n_targets)
+        Encoded training labels. Only set when ``n_targets_ > 1``.
     """
 
     def __init__(
@@ -433,8 +448,9 @@ class TabICLClassifier(ClassifierMixin, TabICLBaseEstimator):
         X : array-like of shape (n_samples, n_features)
             Training input data.
 
-        y : array-like of shape (n_samples,)
-            Training target labels.
+        y : array-like of shape (n_samples,) or (n_samples, n_targets)
+            Training target labels. For multi-target classification, pass a 2D
+            array where each column is a separate classification target.
 
         Returns
         -------
@@ -453,6 +469,38 @@ class TabICLClassifier(ClassifierMixin, TabICLBaseEstimator):
 
         X, y = validate_data(self, X, y, dtype=None, skip_check_array=True)
         check_classification_targets(y)
+        y = np.asarray(y)
+
+        # Warn and flatten 2D column-vector y
+        if y.ndim == 2 and y.shape[1] == 1:
+            from sklearn.exceptions import DataConversionWarning
+
+            warnings.warn(
+                "A column-vector y was passed when a 1d array was expected. Please change "
+                "the shape of y to (n_samples, ), for example using ravel().",
+                DataConversionWarning,
+                stacklevel=2,
+            )
+            y = y.ravel()
+
+        # Multi-target
+        if y.ndim == 2 and y.shape[1] > 1:
+            self.n_targets_ = y.shape[1]
+            self.y_encoders_ = [LabelEncoder() for _ in range(y.shape[1])]
+            self.y_train_encoded_ = np.column_stack(
+                [enc.fit_transform(y[:, t]) for t, enc in enumerate(self.y_encoders_)]
+            )
+            self.classes_list_ = [enc.classes_ for enc in self.y_encoders_]
+            self.n_classes_list_ = [len(c) for c in self.classes_list_]
+            y = self.y_train_encoded_[:, 0]  # representative for EnsembleGenerator
+            # Clean up single-target attributes from a previous fit
+            for attr in ("y_encoder_", "classes_", "n_classes_"):
+                self.__dict__.pop(attr, None)
+        else:
+            self.n_targets_ = 1
+            # Clean up multi-target attributes from a previous fit
+            for attr in ("y_encoders_", "classes_list_", "n_classes_list_", "y_train_encoded_"):
+                self.__dict__.pop(attr, None)
 
         # Device setup
         self._resolve_device()
@@ -466,30 +514,37 @@ class TabICLClassifier(ClassifierMixin, TabICLBaseEstimator):
         self.model_.to(self.device_)
 
         # Encode class labels
-        self.y_encoder_ = LabelEncoder()
-        y = self.y_encoder_.fit_transform(y)
-        self.classes_ = self.y_encoder_.classes_
-        self.n_classes_ = len(self.y_encoder_.classes_)
+        if self.n_targets_ == 1:
+            self.y_encoder_ = LabelEncoder()
+            y = self.y_encoder_.fit_transform(y)
+            self.classes_ = self.y_encoder_.classes_
+            self.n_classes_ = len(self.y_encoder_.classes_)
 
-        if self.n_classes_ > self.model_.max_classes:
-            if self.kv_cache:
+            if self.n_classes_ > self.model_.max_classes:
+                if self.kv_cache:
+                    raise ValueError(
+                        f"KV caching is not supported when the number of classes ({self.n_classes_}) exceeds the max number "
+                        f"of classes ({self.model_.max_classes}) natively supported by the model."
+                    )
+
+                if not self.support_many_classes:
+                    raise ValueError(
+                        f"The number of classes ({self.n_classes_}) exceeds the max number of classes ({self.model_.max_classes}) "
+                        f"natively supported by the model. Consider enabling many-class support which performs mixed-radix "
+                        f"ensembling during column-wise embedding and hierarchical classification during in-context learning."
+                    )
+
+                if self.verbose:
+                    print(
+                        f"The number of classes ({self.n_classes_}) exceeds the max number of classes ({self.model_.max_classes}) "
+                        f"natively supported by the model. Therefore, many-class strategy is enabled to perform mixed-radix "
+                        f"ensembling during column-wise embedding and hierarchical classification during in-context learning."
+                    )
+        else:
+            if max(self.n_classes_list_) > self.model_.max_classes:
                 raise ValueError(
-                    f"KV caching is not supported when the number of classes ({self.n_classes_}) exceeds the max number "
-                    f"of classes ({self.model_.max_classes}) natively supported by the model."
-                )
-
-            if not self.support_many_classes:
-                raise ValueError(
-                    f"The number of classes ({self.n_classes_}) exceeds the max number of classes ({self.model_.max_classes}) "
-                    f"natively supported by the model. Consider enabling many-class support which performs mixed-radix "
-                    f"ensembling during column-wise embedding and hierarchical classification during in-context learning."
-                )
-
-            if self.verbose:
-                print(
-                    f"The number of classes ({self.n_classes_}) exceeds the max number of classes ({self.model_.max_classes}) "
-                    f"natively supported by the model. Therefore, many-class strategy is enabled to perform mixed-radix "
-                    f"ensembling during column-wise embedding and hierarchical classification during in-context learning."
+                    f"Multi-target classification requires all targets to have at most "
+                    f"{self.model_.max_classes} classes, but found {max(self.n_classes_list_)}."
                 )
 
         #  Transform input features
@@ -497,19 +552,37 @@ class TabICLClassifier(ClassifierMixin, TabICLBaseEstimator):
         X = self.X_encoder_.fit_transform(X)
 
         # Fit ensemble generator to create multiple dataset views
-        self.ensemble_generator_ = EnsembleGenerator(
-            classification=True,
-            n_estimators=self.n_estimators,
-            norm_methods=self.norm_methods or ["none", "power"],
-            feat_shuffle_method=self.feat_shuffle_method,
-            class_shuffle_method=self.class_shuffle_method,
-            outlier_threshold=self.outlier_threshold,
-            random_state=self.random_state,
-        )
+        if self.n_targets_ == 1:
+            self.ensemble_generator_ = EnsembleGenerator(
+                classification=True,
+                n_estimators=self.n_estimators,
+                norm_methods=self.norm_methods or ["none", "power"],
+                feat_shuffle_method=self.feat_shuffle_method,
+                class_shuffle_method=self.class_shuffle_method,
+                outlier_threshold=self.outlier_threshold,
+                random_state=self.random_state,
+            )
+        else:
+            # classification=False: each target has a different class space,
+            # so class shuffling cannot be applied uniformly across targets.
+            self.ensemble_generator_ = EnsembleGenerator(
+                classification=False,
+                n_estimators=self.n_estimators,
+                norm_methods=self.norm_methods or ["none", "power"],
+                feat_shuffle_method=self.feat_shuffle_method,
+                outlier_threshold=self.outlier_threshold,
+                random_state=self.random_state,
+            )
         self.ensemble_generator_.fit(X, y)
 
         self.model_kv_cache_ = None
-        if self.kv_cache:
+        self.cache_mode_ = None
+        if self.kv_cache and self.n_targets_ > 1:
+            warnings.warn(
+                "KV caching is not supported for multi-target prediction and will be ignored.",
+                stacklevel=2,
+            )
+        if self.kv_cache and self.n_targets_ == 1:
             if self.kv_cache is True or self.kv_cache == "kv":
                 self.cache_mode_ = "kv"
             elif self.kv_cache == "repr":
@@ -678,8 +751,10 @@ class TabICLClassifier(ClassifierMixin, TabICLBaseEstimator):
 
         Returns
         -------
-        np.ndarray of shape (n_samples, n_classes)
-            Class probabilities for each test sample.
+        np.ndarray of shape (n_samples, n_classes) or list[np.ndarray]
+            Class probabilities for each test sample. For multi-target
+            classifiers, returns a list of arrays, one per target, where the
+            *i*-th array has shape ``(n_samples, n_classes_i)``.
         """
         check_is_fitted(self)
         if isinstance(X, np.ndarray) and len(X.shape) == 1:
@@ -742,6 +817,13 @@ class TabICLClassifier(ClassifierMixin, TabICLBaseEstimator):
 
         X = self.X_encoder_.transform(X)
 
+        # Multi-target prediction
+        if self.n_targets_ > 1:
+            result = self._predict_proba_multi_target(X, feature_mask)
+            if self.n_jobs is not None:
+                torch.set_num_threads(old_n_threads)
+            return result
+
         # Skip KV cache when features are masked
         has_kv_cache = hasattr(self, "model_kv_cache_") and self.model_kv_cache_ is not None
         use_cache = has_kv_cache and feature_mask is None
@@ -795,6 +877,28 @@ class TabICLClassifier(ClassifierMixin, TabICLBaseEstimator):
         # Normalize probabilities
         return avg / avg.sum(axis=1, keepdims=True)
 
+    def _predict_proba_multi_target(self, X, feature_mask):
+        """Predict class probabilities for each target separately."""
+        data = self.ensemble_generator_.transform(X, mode="both", feature_mask=feature_mask)
+        results = []
+        for t in range(self.n_targets_):
+            outputs = []
+            for norm_method, (Xs, _) in data.items():
+                if feature_mask is None:
+                    fs = self.ensemble_generator_.feature_shuffles_[norm_method]
+                else:
+                    fs = self.ensemble_generator_.masked_feature_shuffles_[norm_method]
+                ys = np.tile(self.y_train_encoded_[:, t], (Xs.shape[0], 1))
+                outputs.append(self._batch_forward(Xs, ys, np.array(fs)))
+
+            arr = np.concatenate(outputs, axis=0)
+            avg = np.mean(arr, axis=0)
+            if self.average_logits:
+                avg = self.softmax(avg, axis=-1, temperature=self.softmax_temperature)
+            avg = avg[:, :self.n_classes_list_[t]]
+            results.append(avg / avg.sum(axis=1, keepdims=True))
+        return results
+
     def predict(self, X: np.ndarray) -> np.ndarray:
         """Predict class labels for test samples.
 
@@ -811,9 +915,18 @@ class TabICLClassifier(ClassifierMixin, TabICLBaseEstimator):
 
         Returns
         -------
-        array-like of shape (n_samples,)
-            Predicted class labels for each test sample.
+        np.ndarray of shape (n_samples,) or (n_samples, n_targets)
+            Predicted class labels for each test sample. For multi-target
+            classifiers, returns a 2D array of shape ``(n_samples, n_targets)``.
         """
+        check_is_fitted(self)
+        if self.n_targets_ > 1:
+            probas = self.predict_proba(X)
+            return np.column_stack([
+                self.y_encoders_[t].inverse_transform(np.argmax(p, axis=1))
+                for t, p in enumerate(probas)
+            ])
+
         proba = self.predict_proba(X)
         y = np.argmax(proba, axis=1)
 

--- a/src/tabicl/sklearn/regressor.py
+++ b/src/tabicl/sklearn/regressor.py
@@ -233,6 +233,15 @@ class TabICLRegressor(RegressorMixin, TabICLBaseEstimator):
         Created during ``fit()`` when ``kv_cache`` is enabled. When set,
         ``predict()`` reuses the cached key-value projections instead of
         re-processing training data, enabling faster inference on multiple test sets.
+
+    n_targets_ : int
+        Number of targets. 1 for single-target, >1 for multi-target.
+
+    y_scalers_ : list[StandardScaler]
+        Per-target scalers. Only set when ``n_targets_ > 1``.
+
+    y_train_scaled_ : ndarray of shape (n_samples, n_targets)
+        Scaled training targets. Only set when ``n_targets_ > 1``.
     """
 
     def __init__(
@@ -367,8 +376,9 @@ class TabICLRegressor(RegressorMixin, TabICLBaseEstimator):
         X : array-like of shape (n_samples, n_features)
             Training input data.
 
-        y : array-like of shape (n_samples,)
-            Training target values.
+        y : array-like of shape (n_samples,) or (n_samples, n_targets)
+            Training target values. For multi-target regression, pass a 2D
+            array where each column is a separate regression target.
 
         Returns
         -------
@@ -396,6 +406,22 @@ class TabICLRegressor(RegressorMixin, TabICLBaseEstimator):
             )
             y = y.ravel()
 
+        # Handle multi-target y
+        if y.ndim == 2 and y.shape[1] > 1:
+            self.n_targets_ = y.shape[1]
+            self.y_scalers_ = [StandardScaler() for _ in range(y.shape[1])]
+            self.y_train_scaled_ = np.column_stack(
+                [s.fit_transform(y[:, i : i + 1]).ravel() for i, s in enumerate(self.y_scalers_)]
+            )
+            y_scaled = self.y_train_scaled_[:, 0]  # representative for EnsembleGenerator (X-only)
+            # Clean up single-target attributes from a previous fit
+            self.__dict__.pop("y_scaler_", None)
+        else:
+            self.n_targets_ = 1
+            # Clean up multi-target attributes from a previous fit
+            for attr in ("y_scalers_", "y_train_scaled_"):
+                self.__dict__.pop(attr, None)
+
         # Device setup
         self._resolve_device()
 
@@ -408,8 +434,9 @@ class TabICLRegressor(RegressorMixin, TabICLBaseEstimator):
         self.model_.to(self.device_)
 
         # Scale target values
-        self.y_scaler_ = StandardScaler()
-        y_scaled = self.y_scaler_.fit_transform(y.reshape(-1, 1)).flatten()
+        if self.n_targets_ == 1:
+            self.y_scaler_ = StandardScaler()
+            y_scaled = self.y_scaler_.fit_transform(y.reshape(-1, 1)).flatten()
 
         # Transform input features
         self.X_encoder_ = TransformToNumerical(verbose=self.verbose)
@@ -427,7 +454,13 @@ class TabICLRegressor(RegressorMixin, TabICLBaseEstimator):
         self.ensemble_generator_.fit(X, y_scaled)
 
         self.model_kv_cache_ = None
-        if self.kv_cache:
+        self.cache_mode_ = None
+        if self.kv_cache and self.n_targets_ > 1:
+            warnings.warn(
+                "KV caching is not supported for multi-target prediction and will be ignored.",
+                stacklevel=2,
+            )
+        if self.kv_cache and self.n_targets_ == 1:
             if self.kv_cache is True or self.kv_cache == "kv":
                 self.cache_mode_ = "kv"
             elif self.kv_cache == "repr":
@@ -652,10 +685,16 @@ class TabICLRegressor(RegressorMixin, TabICLBaseEstimator):
 
         Returns
         -------
-        np.ndarray of shape (n_samples,) or dict[str, np.ndarray]
-            An array of shape ``(n_samples,)`` if ``output_type`` is ``"mean"`` or
-            ``"median"``, or an array of shape ``(n_samples, n_quantiles)`` if
-            ``output_type`` is ``"quantiles"`` or ``"raw_quantiles"``.
+        np.ndarray or dict[str, np.ndarray]
+            For single-target regression:
+
+            - ``"mean"`` or ``"median"``: array of shape ``(n_samples,)``
+            - ``"quantiles"`` or ``"raw_quantiles"``: array of shape ``(n_samples, n_quantiles)``
+
+            For multi-target regression:
+
+            - ``"mean"`` or ``"median"``: array of shape ``(n_samples, n_targets)``
+            - ``"quantiles"`` or ``"raw_quantiles"``: array of shape ``(n_samples, n_quantiles, n_targets)``
 
             If ``output_type`` is a list of str, returns a dictionary with keys as
             specified in the list and values as the corresponding predictions.
@@ -723,6 +762,13 @@ class TabICLRegressor(RegressorMixin, TabICLBaseEstimator):
 
         output_type = [output_type] if isinstance(output_type, str) else list(output_type)
 
+        # Multi-target prediction
+        if self.n_targets_ > 1:
+            result = self._predict_multi_target(X, output_type, feature_mask, alphas)
+            if self.n_jobs is not None:
+                torch.set_num_threads(old_n_threads)
+            return result
+
         # Skip KV cache when features are masked
         has_kv_cache = hasattr(self, "model_kv_cache_") and self.model_kv_cache_ is not None
         use_cache = has_kv_cache and feature_mask is None
@@ -775,6 +821,46 @@ class TabICLRegressor(RegressorMixin, TabICLBaseEstimator):
             return final_results[output_type[0]]
 
         return final_results
+
+    def _predict_multi_target(self, X, output_type, feature_mask, alphas=None):
+        """Predict multiple targets by looping over targets internally.
+
+        Reuses ensemble-transformed X data across targets for efficiency.
+        """
+        data = self.ensemble_generator_.transform(X, mode="both", feature_mask=feature_mask)
+        all_preds = {key: [] for key in output_type}
+
+        for t in range(self.n_targets_):
+            results = {key: [] for key in output_type}
+            for Xs, _ in data.values():
+                ys = np.tile(self.y_train_scaled_[:, t], (Xs.shape[0], 1))
+                batch_out = self._batch_forward(Xs, ys, output_type=output_type, alphas=alphas)
+                if isinstance(batch_out, dict):
+                    for key in output_type:
+                        results[key].append(batch_out[key])
+                else:
+                    results[output_type[0]].append(batch_out)
+
+            for key in output_type:
+                arr = np.concatenate(results[key], axis=0)
+                n_estimators = arr.shape[0]
+                n_samples = arr.shape[1]
+                if arr.ndim == 2:
+                    arr = self.y_scalers_[t].inverse_transform(arr.reshape(-1, 1)).reshape(n_estimators, n_samples)
+                    all_preds[key].append(np.mean(arr, axis=0))
+                else:
+                    n_quantiles = arr.shape[2]
+                    arr = self.y_scalers_[t].inverse_transform(arr.reshape(-1, 1)).reshape(
+                        n_estimators, n_samples, n_quantiles
+                    )
+                    all_preds[key].append(np.mean(arr, axis=0))
+
+        for key in all_preds:
+            all_preds[key] = np.stack(all_preds[key], axis=-1)
+
+        if len(output_type) == 1:
+            return all_preds[output_type[0]]
+        return all_preds
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -49,3 +49,145 @@ class TestRegressorKVCache:
 
         # Relaxed tolerance: kv cache changes float32 computation order
         np.testing.assert_allclose(pred_no_cache, pred_cached, rtol=1e-4, atol=1e-4)
+
+
+class TestClassifierMultiTarget:
+    def test_multi_target_output_shape(self):
+        """1D y -> proba (n, nc), pred (n,). 2D y -> proba is list of 3, pred (n, 3)."""
+        rng = np.random.RandomState(42)
+        X, y0 = make_classification(n_samples=50, n_features=5, random_state=42)
+        y_multi = np.column_stack([y0, rng.randint(0, 3, 50), rng.randint(0, 2, 50)])
+        X_train, X_test = X[:40], X[40:]
+
+        # 1D y
+        clf_1d = TabICLClassifier(n_estimators=2)
+        clf_1d.fit(X_train, y0[:40])
+        proba_1d = clf_1d.predict_proba(X_test)
+        pred_1d = clf_1d.predict(X_test)
+        assert proba_1d.shape == (10, 2)
+        assert pred_1d.shape == (10,)
+
+        # 2D y
+        clf_2d = TabICLClassifier(n_estimators=2)
+        clf_2d.fit(X_train, y_multi[:40])
+        proba_2d = clf_2d.predict_proba(X_test)
+        pred_2d = clf_2d.predict(X_test)
+        assert isinstance(proba_2d, list)
+        assert len(proba_2d) == 3
+        assert proba_2d[0].shape == (10, 2)  # binary
+        assert proba_2d[1].shape == (10, 3)  # 3-class
+        assert proba_2d[2].shape == (10, 2)  # binary
+        assert pred_2d.shape == (10, 3)
+
+    def test_multi_target_fit_attributes(self):
+        """2D: n_targets_==3, len(y_encoders_)==3. 1D: n_targets_==1, has y_encoder_."""
+        rng = np.random.RandomState(42)
+        X, y0 = make_classification(n_samples=50, n_features=5, random_state=42)
+        y_multi = np.column_stack([y0, rng.randint(0, 3, 50), rng.randint(0, 2, 50)])
+
+        # 2D y
+        clf_multi = TabICLClassifier(n_estimators=2)
+        clf_multi.fit(X, y_multi)
+        assert clf_multi.n_targets_ == 3
+        assert len(clf_multi.y_encoders_) == 3
+        assert clf_multi.y_train_encoded_.shape == (50, 3)
+
+        # 1D y
+        clf_single = TabICLClassifier(n_estimators=2)
+        clf_single.fit(X, y0)
+        assert clf_single.n_targets_ == 1
+        assert hasattr(clf_single, "y_encoder_")
+        assert not hasattr(clf_single, "y_encoders_")
+
+    def test_multi_target_matches_single_target(self):
+        """Multi-target and single-target classifiers should largely agree on labels."""
+        rng = np.random.RandomState(42)
+        X, y0 = make_classification(n_samples=50, n_features=5, random_state=42)
+        y_multi = np.column_stack([y0, rng.randint(0, 3, 50), rng.randint(0, 2, 50)])
+        X_train, X_test = X[:40], X[40:]
+
+        # Multi-target
+        clf_multi = TabICLClassifier(n_estimators=2, random_state=42)
+        clf_multi.fit(X_train, y_multi[:40])
+        pred_multi = clf_multi.predict(X_test)
+
+        # Single-target per column
+        for t in range(3):
+            clf_single = TabICLClassifier(n_estimators=2, random_state=42)
+            clf_single.fit(X_train, y_multi[:40, t])
+            pred_single = clf_single.predict(X_test)
+            agreement = np.mean(pred_multi[:, t] == pred_single)
+            assert agreement >= 0.5, (
+                f"Target {t}: only {agreement:.0%} agreement between multi- and single-target"
+            )
+
+    def test_multi_target_predict(self):
+        """Labels belong to correct per-target classes."""
+        rng = np.random.RandomState(42)
+        X, y0 = make_classification(n_samples=50, n_features=5, random_state=42)
+        y_multi = np.column_stack([y0, rng.randint(0, 3, 50), rng.randint(0, 2, 50)])
+        X_train, X_test = X[:40], X[40:]
+
+        clf = TabICLClassifier(n_estimators=2)
+        clf.fit(X_train, y_multi[:40])
+        pred = clf.predict(X_test)
+        for t in range(3):
+            assert set(pred[:, t]).issubset(set(y_multi[:40, t]))
+
+
+class TestRegressorMultiTarget:
+    def test_multi_target_matches_single_target(self):
+        """Multi-target predictions should match individual single-target models."""
+        X, y = make_regression(n_samples=50, n_features=5, n_targets=3, random_state=42)
+        X_train, X_test = X[:40], X[40:]
+        y_train = y[:40]
+
+        # Fit separate single-target models
+        single_preds = []
+        for t in range(3):
+            reg = TabICLRegressor(n_estimators=2, random_state=42)
+            reg.fit(X_train, y_train[:, t])
+            single_preds.append(reg.predict(X_test))
+
+        # Fit one multi-target model
+        reg_multi = TabICLRegressor(n_estimators=2, random_state=42)
+        reg_multi.fit(X_train, y_train)
+        multi_preds = reg_multi.predict(X_test)
+
+        for t in range(3):
+            np.testing.assert_allclose(multi_preds[:, t], single_preds[t], rtol=1e-4, atol=1e-4)
+
+    def test_multi_target_output_shape(self):
+        """Verify output shapes for 1D and 2D y."""
+        X, y = make_regression(n_samples=50, n_features=5, n_targets=3, random_state=42)
+        X_train, X_test = X[:40], X[40:]
+
+        # 1D y -> (n_test,)
+        reg_1d = TabICLRegressor(n_estimators=2, random_state=42)
+        reg_1d.fit(X_train, y[:40, 0])
+        pred_1d = reg_1d.predict(X_test)
+        assert pred_1d.shape == (10,)
+
+        # 2D y -> (n_test, 3)
+        reg_2d = TabICLRegressor(n_estimators=2, random_state=42)
+        reg_2d.fit(X_train, y[:40])
+        pred_2d = reg_2d.predict(X_test)
+        assert pred_2d.shape == (10, 3)
+
+    def test_multi_target_fit_attributes(self):
+        """Verify fit() sets correct attributes for single vs multi-target."""
+        X, y = make_regression(n_samples=50, n_features=5, n_targets=3, random_state=42)
+
+        # 2D y
+        reg_multi = TabICLRegressor(n_estimators=2, random_state=42)
+        reg_multi.fit(X, y)
+        assert reg_multi.n_targets_ == 3
+        assert len(reg_multi.y_scalers_) == 3
+        assert reg_multi.y_train_scaled_.shape == (50, 3)
+
+        # 1D y
+        reg_single = TabICLRegressor(n_estimators=2, random_state=42)
+        reg_single.fit(X, y[:, 0])
+        assert reg_single.n_targets_ == 1
+        assert hasattr(reg_single, "y_scaler_")
+        assert not hasattr(reg_single, "y_scalers_")


### PR DESCRIPTION
I've put together this PR to support 2D y arrays in TabICLClassifier and TabICLRegressor for multi-target prediction. Each target is processed independently through the existing single-target pipeline, and results are stacked.

It is useful in some contexts where I can max out GPU memory and do predictions over multiple columns in parallel. I understand the use case might be niche and so it might not be very useful for the project repo. 

Thanks again for sharing weights and code!