### PR TITLE
Fix: allow NaN input in preprocessing pipeline

### DIFF
--- a/src/tabicl/sklearn/sklearn_utils.py
+++ b/src/tabicl/sklearn/sklearn_utils.py
@@ -370,6 +370,9 @@ def validate_data(
         raise ValueError("Validation should be done on X, y or both.")
 
     default_check_params = {"estimator": _estimator}
+    # Allow NaN by default — the preprocessing pipeline handles imputation
+    # via SimpleImputer before data reaches the model.
+    check_params.setdefault("force_all_finite", "allow-nan")
     check_params = {**default_check_params, **check_params}
 
     if skip_check_array:


### PR DESCRIPTION
## Summary

`TabICLClassifier.fit()` raises `ValueError: Input X contains NaN` despite the README documenting mean imputation for missing numerical values.

The `PreprocessingPipeline` correctly includes a `SimpleImputer` for numeric columns (line 118 of `preprocessing.py`), but `validate_data()` calls throughout the preprocessing chain reject NaN **before** the imputer has a chance to run.

## Reproduction

```python
import numpy as np
from tabicl import TabICLClassifier

X = np.array([[1.0, 2.0], [4.0, np.nan], [7.0, 8.0]], dtype=np.float32)
y = np.array(["a", "b", "a"])

clf = TabICLClassifier(device="cpu", n_estimators=1)
clf.fit(X, y)  # ValueError: Input X contains NaN.
```

## Root cause

`validate_data()` in `sklearn_utils.py` is called by `EnsembleGenerator`, `UniqueFeatureFilter`, `OutlierRemover`, `CustomStandardScaler`, and `PreprocessingPipeline` — all **before** the `SimpleImputer` in the `ColumnTransformer` runs. sklearn's `check_array` rejects NaN by default.

## Fix

One-line change: set `force_all_finite="allow-nan"` as the default in `validate_data()`. This is safe because the `SimpleImputer` handles NaN downstream, and the remaining preprocessors (`OutlierRemover`, `CustomStandardScaler`) already use `np.nanmean`/`np.nanstd`.

Note: `force_all_finite` was renamed to `ensure_all_finite` in sklearn 1.6. Since tabicl supports `scikit-learn>=1.3.0`, this PR uses the older name for backwards compatibility.

## Testing

Verified locally with tabicl 2.0.3 + scikit-learn 1.6.1:
- NaN input: fit/predict works correctly after fix
- Clean input: no change in behavior