### PR TITLE
fix: use mix_probs key in SCMPrior

### DIFF
--- a/src/tabicl/prior/_dataset.py
+++ b/src/tabicl/prior/_dataset.py
@@ -716,7 +716,7 @@ class SCMPrior(Prior):
             The selected prior type name.
         """
         if self.prior_type == "mix_scm":
-            return np.random.choice(["mlp_scm", "tree_scm"], p=self.fixed_hp.get("mix_probas", [0.7, 0.3]))
+            return np.random.choice(["mlp_scm", "tree_scm"], p=self.fixed_hp.get("mix_probs", [0.7, 0.3]))
         else:
             return self.prior_type
 


### PR DESCRIPTION
Fixes #104

This updates `SCMPrior._select_prior_type` to read the configured `mix_probs` key, matching `DEFAULT_FIXED_HP` in `_prior_config.py`.

Testing: ran `python3 -m compileall src/tabicl/prior/_dataset.py` and `git diff --check`.