### PR TITLE
n_threads is set to the maximum of n_logical_cores and n_jobs, rather than minimum

### DIFF
--- a/src/tabicl/_sklearn/classifier.py
+++ b/src/tabicl/_sklearn/classifier.py
@@ -711,9 +711,9 @@ class TabICLClassifier(ClassifierMixin, TabICLBaseEstimator):
                         f"TabICL got n_jobs={self.n_jobs} but there are only {n_logical_cores} logical cores available."
                         f" Only {n_logical_cores} threads will be used."
                     )
-                n_threads = max(n_logical_cores, self.n_jobs)
+                n_threads = min(n_logical_cores, self.n_jobs)
             else:
-                n_threads = max(1, mp.cpu_count() + 1 + self.n_jobs)
+                n_threads = max(1, n_logical_cores + 1 + self.n_jobs)
 
             torch.set_num_threads(n_threads)
 

--- a/src/tabicl/_sklearn/regressor.py
+++ b/src/tabicl/_sklearn/regressor.py
@@ -690,9 +690,9 @@ class TabICLRegressor(RegressorMixin, TabICLBaseEstimator):
                         f"TabICL got n_jobs={self.n_jobs} but there are only {n_logical_cores} logical cores available."
                         f" Only {n_logical_cores} threads will be used."
                     )
-                n_threads = max(n_logical_cores, self.n_jobs)
+                n_threads = min(n_logical_cores, self.n_jobs)
             else:
-                n_threads = max(1, mp.cpu_count() + 1 + self.n_jobs)
+                n_threads = max(1, n_logical_cores + 1 + self.n_jobs)
 
             torch.set_num_threads(n_threads)
 


### PR DESCRIPTION
The logic for setting `n_threads` in `src/tabicl/_sklearn/classifier.py` and `src/tabicl/_sklearn/regressor.py` incorrectly sets `n_threads = max(n_logical_cores, self.n_jobs)`, meaning that if `n_jobs < n_logical_cores` then all logical cores will be used. This PR changes that line to `n_threads = min(n_logical_cores, self.n_jobs)`.

I've also swapped the `mp.cpu_count()` in the else branch for the `n_logical_cores` variable that is already computed.

We would really appreciate a release with this fix. Congratulations on the ICML acceptance!