### PR TITLE
[EHN] Remove gluonts dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,16 +3,6 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-import warnings
-
-# Suppress known gluonts warning on Python >= 3.14 during docs builds.
-warnings.filterwarnings(
-    "ignore",
-    message="Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.",
-    category=UserWarning,
-    module="gluonts\\.pydantic",
-)
-
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ doc = [
 ]
 forecast = [                                                                                                                                                                                                        
     "pandas>=2.1.2",
-    "gluonts>=0.16.0",  # calendar features
     "statsmodels>=0.14.5",  # seasonal detection
     "matplotlib>=3.10.3",  # plotting
 ]
@@ -126,10 +125,11 @@ exclude_lines = [
 ]
 
 [tool.uv]
-# gluonts pins an old numpy version which is not available for Python 3.14. The
-# following override is a temporary workaround to avoid having uv build numpy
-# from source on Python 3.14 and later.
-override-dependencies = [
-    "numpy>=2.4; python_version >= '3.14'",
-    "numpy; python_version < '3.14'",
+# Cooldown period for PyPI releases to mitigate supply chain attacks.
+exclude-newer = "7 days"
+# Must resolve dependencies for major platforms in uv.lock
+required-environments = [
+    "sys_platform == 'darwin'",
+    "sys_platform == 'linux'",
+    "sys_platform == 'win32'",
 ]

--- a/src/tabicl/forecast/_ts_dataframe.py
+++ b/src/tabicl/forecast/_ts_dataframe.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type, Union, overl
 import numpy as np
 import pandas as pd
 from joblib.parallel import Parallel, delayed
-from pandas.core.internals import ArrayManager, BlockManager
+from pandas.core.internals import BlockManager
 from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
@@ -133,7 +133,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         *args,
         **kwargs,
     ):
-        if isinstance(data, (BlockManager, ArrayManager)):
+        if isinstance(data, BlockManager):
             # necessary for copy constructor to work in pandas <= 2.0.x. In >= 2.1.x this is replaced by _constructor_from_mgr
             pass
         elif isinstance(data, pd.DataFrame):

--- a/src/tabicl/forecast/transforms/_calendar.py
+++ b/src/tabicl/forecast/transforms/_calendar.py
@@ -34,6 +34,16 @@ _SEASONAL_MAPPINGS = {
     "day_of_month": "day",
     "month_of_year": "month",
 }
+_ZERO_INDEXED = {
+    "second",
+    "minute",
+    "hour",
+    "dayofweek",
+    "day_of_week",
+    "weekday",
+    "microsecond",
+    "nanosecond",
+}
 
 
 class DatetimeEncoder(TimeTransform):
@@ -96,8 +106,11 @@ class DatetimeEncoder(TimeTransform):
             if feature_name not in ["week_of_year", "week", "weekofyear"]:
                 feature_name_ = _SEASONAL_MAPPINGS.get(feature_name, feature_name)
                 feature = getattr(timestamps, feature_name_).astype(np.int32)
+                if feature_name_ not in _ZERO_INDEXED:
+                    feature -= 1  # Adjust for 0-based indexing
             else:
-                feature = timestamps.isocalendar().week.values.astype(np.int32)
+                feature = timestamps.isocalendar().week.to_numpy(dtype=np.int32)
+                feature -= 1  # Adjust for 0-based indexing
 
             if periods is not None:
                 for p in periods:

--- a/src/tabicl/forecast/transforms/_calendar.py
+++ b/src/tabicl/forecast/transforms/_calendar.py
@@ -41,7 +41,7 @@ class DatetimeEncoder(TimeTransform):
 
     Extracts calendar components (e.g., year) and encodes seasonal
     patterns (e.g., hour of day, day of week) as sin/cosine pairs using
-    ``gluonts.time_feature``.
+    ``pd.DatetimeIndex`` attributes.
 
     Parameters
     ----------
@@ -97,7 +97,7 @@ class DatetimeEncoder(TimeTransform):
                 feature_name_ = _SEASONAL_MAPPINGS.get(feature_name, feature_name)
                 feature = getattr(timestamps, feature_name_).astype(np.int32)
             else:
-                feature = timestamps.isocalendar().week.astype(np.int32)
+                feature = timestamps.isocalendar().week.values.astype(np.int32)
 
             if periods is not None:
                 for p in periods:

--- a/src/tabicl/forecast/transforms/_calendar.py
+++ b/src/tabicl/forecast/transforms/_calendar.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
-import gluonts.time_feature
 
 from tabicl.forecast.transforms._base import TimeTransform
 
@@ -27,6 +26,14 @@ class IndexEncoder(TimeTransform):
             DataFrame with an added ``running_index`` column.
         """
         return df.assign(running_index=range(len(df)))
+
+_SEASONAL_MAPPINGS = {
+    "second_of_minute": "second",
+    "minute_of_hour": "minute",
+    "hour_of_day": "hour",
+    "day_of_month": "day",
+    "month_of_year": "month",
+}
 
 
 class DatetimeEncoder(TimeTransform):
@@ -80,13 +87,17 @@ class DatetimeEncoder(TimeTransform):
         """
         df = df.copy()
         timestamps = df.index.get_level_values("timestamp")
+        assert isinstance(timestamps, pd.DatetimeIndex), "Index must have a 'timestamp' level of type DatetimeIndex"
 
         for component in self.components:
             df[component] = getattr(timestamps, component)
 
         for feature_name, periods in self.seasonal_features.items():
-            feature_func = getattr(gluonts.time_feature, f"{feature_name}_index")
-            feature = feature_func(timestamps).astype(np.int32)
+            if feature_name not in ["week_of_year", "week", "weekofyear"]:
+                feature_name_ = _SEASONAL_MAPPINGS.get(feature_name, feature_name)
+                feature = getattr(timestamps, feature_name_).astype(np.int32)
+            else:
+                feature = timestamps.isocalendar().week.astype(np.int32)
 
             if periods is not None:
                 for p in periods:


### PR DESCRIPTION
## Summary
`gluonts` as a dependency has caused some issues for uv resolution, whereas it was only being used in `src/tabicl/forecast/transforms/_calendar.py`. This PR removes `gluonts` as a dependency and replace `gluonts.time_feature` with `pd.DatetimeIndex`.

Also, add a 7-day cool-down period for uv resolution to reduce [supply-chain risks](https://thehackernews.com/2026/04/pytorch-lightning-compromised-in-pypi.html).

I asked Codex to write the following description:

### What changed
- Removed `gluonts` from the `forecast` optional dependencies in `pyproject.toml`.
- Reworked `DatetimeEncoder` in `src/tabicl/forecast/transforms/_calendar.py`:
  - dropped `gluonts.time_feature` import/use
  - added pandas-based seasonal feature extraction (including week handling via `isocalendar().week`)
  - added seasonal name mappings for compatibility (`second_of_minute`, `minute_of_hour`, etc.)
  - added an assertion that the `timestamp` level is a `pd.DatetimeIndex`
- Removed docs warning suppression in `docs/conf.py` that existed only for `gluonts`/pydantic compatibility.

## Motivation
`gluonts` introduced compatibility and dependency resolution friction (notably around newer Python/Numpy environments). The forecast transforms only needed calendar feature extraction, which can be implemented directly with pandas.

## Impact
- Forecast extra is lighter and avoids pulling `gluonts`.
- Calendar feature behavior is preserved through equivalent pandas-based feature computation.
- Docs config is simplified (no package-specific warning filter needed).

## Testing
None, there are no forecasting unit tests AFAIK.

I used the example from README for local testing.

## Notes
- `uv.lock` is currently untracked in the working tree. Include it in this PR if you want lockfile updates committed with the dependency change.

cc: @JingangQu @dholzmueller @marineLM