### PR TITLE
fix default behaviour on NumPy array with strings

### DIFF
--- a/src/tabicl/_sklearn/preprocessing.py
+++ b/src/tabicl/_sklearn/preprocessing.py
@@ -103,25 +103,44 @@ class TransformToNumerical(TransformerMixin, BaseEstimator):
         num_tfm = SimpleImputer()
 
         if not hasattr(X, "columns"):  # proxy way to check whether X is a dataframe without importing pandas
-            # no dataframe
-            # check if dtype is bool, object, byte sting, or unicode string
-            is_categorical = np.asarray(X).dtype.kind in {"b", "O", "S", "U"}
-            self.tfm_ = cat_tfm if is_categorical else num_tfm
-            self.tfm_.fit(X)
-            return self
+            # no dataframe, so we can't do column-wise transformations. Instead, we check if it's already numeric and if not, raise an error.
+            X_arr = np.asarray(X)
+            try:
+                X_arr.astype(np.float64)
+            except (ValueError, TypeError) as e:
+                raise ValueError(
+                    "NumPy arrays passed to TabICL must be castable to a numeric dtype, "
+                    f"but casting to float64 failed with: {e}. "
+                    "If your data contains categorical or string columns, pass it as a pandas "
+                    "DataFrame instead, so each column can be typed and preprocessed accordingly."
+                ) from None
+            self.tfm_ = num_tfm
 
-        cat_cols = make_column_selector(dtype_include=["string", "object", "category", "boolean"])(X)
-        cat_pos = [X.columns.get_loc(col) for col in cat_cols]
+        else:
 
-        numeric_cols = make_column_selector(dtype_include="number")(X)
-        numeric_pos = [X.columns.get_loc(col) for col in numeric_cols]
+            cat_cols = make_column_selector(dtype_include=["string", "object", "category", "boolean"])(X)
+            cat_pos = [X.columns.get_loc(col) for col in cat_cols]
 
-        self.tfm_ = ColumnTransformer(
-            transformers=[("categorical", cat_tfm, cat_pos), ("continuous", num_tfm, numeric_pos)]
-        )
+            high_cardinality_cols = [col for col in cat_cols if X[col].nunique() > 40]
+            if high_cardinality_cols:
+                import warnings
+
+                warnings.warn(
+                    f"The following categorical columns have a cardinality above 40: {high_cardinality_cols}. "
+                    "High-cardinality columns might benefit from a better encoding than ordinal encoding, "
+                    "e.g. Skrub's TableVectorizer for strings."
+                )
+
+            numeric_cols = make_column_selector(dtype_include="number")(X)
+            numeric_pos = [X.columns.get_loc(col) for col in numeric_cols]
+
+            self.tfm_ = ColumnTransformer(
+                transformers=[("categorical", cat_tfm, cat_pos), ("continuous", num_tfm, numeric_pos)]
+            )
+
         self.tfm_.fit(X)
 
-        if self.verbose:
+        if self.verbose and hasattr(self.tfm_, "transformers_"):
             selected_cols = []
             for name, tfm, pos in self.tfm_.transformers_:
                 if tfm != "drop":

--- a/src/tabicl/_sklearn/preprocessing.py
+++ b/src/tabicl/_sklearn/preprocessing.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from typing import List, Optional
 
 import numpy as np
+from scipy.sparse import issparse
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.compose import ColumnTransformer, make_column_selector
 from sklearn.impute import SimpleImputer
@@ -104,11 +105,20 @@ class TransformToNumerical(TransformerMixin, BaseEstimator):
 
         if not hasattr(X, "columns"):  # proxy way to check whether X is a dataframe without importing pandas
             # no dataframe, so we can't do column-wise transformations. Instead, we check if it's already numeric and if not, raise an error.
+            
+            # For compatibility with sklearn's tests
+            if issparse(X):
+                raise TypeError(
+                    "Sparse input is not supported by TabICL. "
+                    "Convert X to a dense array, e.g. with X.toarray()."
+                )
             X_arr = np.asarray(X)
             try:
                 X_arr.astype(np.float64)
             except (ValueError, TypeError) as e:
-                raise ValueError(
+                # Preserve the original exception type so that, e.g., object arrays
+                # holding non-string/non-number elements still raise a TypeError.
+                raise type(e)(
                     "NumPy arrays passed to TabICL must be castable to a numeric dtype, "
                     f"but casting to float64 failed with: {e}. "
                     "If your data contains categorical or string columns, pass it as a pandas "

--- a/tests/test_string_input.py
+++ b/tests/test_string_input.py
@@ -5,10 +5,9 @@ from sklearn.base import is_classifier, is_regressor
 
 from tabicl import TabICLClassifier, TabICLRegressor
 
-@pytest.mark.parametrize("container", ["dataframe", "numpy_object"])
 @pytest.mark.parametrize("Estimator", [TabICLClassifier, TabICLRegressor])
-def test_handles_string_inputs_without_crashing(Estimator, container):
-    """Estimator should not crash with string-valued inputs in different containers."""
+def test_handles_string_dataframe_without_crashing(Estimator):
+    """Estimator should not crash with string-valued columns in a DataFrame."""
 
     rng = np.random.RandomState(0)
     n = 20
@@ -18,30 +17,17 @@ def test_handles_string_inputs_without_crashing(Estimator, container):
     obj_str = pd.Series(rng.choice(["a", "b", "c"], size=n), dtype=object)
     str_dtype = pd.Series(rng.choice(["x", "y", "z"], size=n), dtype="string")
 
-    if container == "dataframe":
-        X = pd.DataFrame(
-            {
-                "num1": num1,
-                "num2": num2,
-                "obj_str": obj_str,      # object dtype
-                "str_dtype": str_dtype,  # pandas string dtype
-            }
-        )
+    X = pd.DataFrame(
+        {
+            "num1": num1,
+            "num2": num2,
+            "obj_str": obj_str,      # object dtype
+            "str_dtype": str_dtype,  # pandas string dtype
+        }
+    )
 
-        assert X["obj_str"].dtype == "object"
-        assert str(X["str_dtype"].dtype).startswith("string")
-
-    elif container == "numpy_object":
-        X = np.empty((n, 4), dtype=object)
-        X[:, 0] = num1
-        X[:, 1] = num2
-        X[:, 2] = obj_str
-        X[:, 3] = rng.choice(["u", "v", "w"], size=n)
-
-        assert X.dtype == object
-
-    else:
-        raise AssertionError(f"Unknown container: {container}")
+    assert X["obj_str"].dtype == "object"
+    assert str(X["str_dtype"].dtype).startswith("string")
 
     est = Estimator()
 
@@ -56,3 +42,31 @@ def test_handles_string_inputs_without_crashing(Estimator, container):
     preds = est.predict(X)
 
     assert len(preds) == n
+
+
+@pytest.mark.parametrize("Estimator", [TabICLClassifier, TabICLRegressor])
+def test_string_numpy_object_array_raises(Estimator):
+    """String-valued NumPy object arrays cannot be reliably typed column-wise,
+    so the estimator should raise an informative error pointing users to DataFrames."""
+
+    rng = np.random.RandomState(0)
+    n = 20
+
+    X = np.empty((n, 4), dtype=object)
+    X[:, 0] = rng.randn(n)
+    X[:, 1] = rng.randn(n)
+    X[:, 2] = rng.choice(["a", "b", "c"], size=n)
+    X[:, 3] = rng.choice(["u", "v", "w"], size=n)
+    assert X.dtype == object
+
+    est = Estimator()
+
+    if is_classifier(est):
+        y = rng.randint(0, 2, size=n)
+    elif is_regressor(est):
+        y = rng.randn(n)
+    else:
+        raise ValueError(f'Estimator is neither classifier nor regressor')
+
+    with pytest.raises(ValueError, match="castable to a numeric dtype"):
+        est.fit(X, y)


### PR DESCRIPTION
**Current behaviour**
For NumPy arrays with mixed types (e.g. one string column alongside numeric ones), the entire array gets dtype=object, causing all columns to be silently ordinal-encoded;  including the numerical ones. Fixing this properly requires per-column type inspection, which looks fragile and hard to maintain to me.

Moreover, ordinal-encoding string columns is not a great default behaviour, notably when strings are very diverse.


**Fixed behaviour**
For NumPy arrays, attempt to cast the data to float64. If it succeeds, proceed with the numerical column transformer. If not, raise a clear error.

For dataframes, the behaviour is unchanged. Just added a warning for high-cardinality columns, as ordinal encoding might not be appropriate for these.