### PR TITLE
doc(readme): remove ambiguity on classification/regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This repository is the official implementation of **TabICLv2** ([ICML 2026](https://arxiv.org/abs/2602.11139)) 
 and **TabICL** ([ICML 2025](https://arxiv.org/abs/2502.05564)).
 
-**State-of-the-art accuracy even without hyperparameter tuning:** 
+**State-of-the-art performance even without hyperparameter tuning:** 
 TabICLv2 is the new state-of-the-art model for tabular classification and regression 
 on the [TabArena](https://tabarena.ai) and [TALENT](https://arxiv.org/abs/2407.00956) benchmarks. 
 It does not require hyperparameter tuning 


### PR DESCRIPTION
Hello!
I was wondering if TabICL was handling regression tasks too, because the name really sounds like classification (ending with "cl"). My first understanding, quickly reading the readme was that it didn't handle, because in bold I saw "accuracy". Then I read more carefully and saw that it actually handles both.  
Yet, to make it clearer, I'm suggesting this small change.