### PR TITLE
Document `skrub.tabular_pipeline`'s new support for TabICL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
+    "skrub": ("https://skrub-data.org/stable/", None),
     "torch": ("https://pytorch.org/docs/stable/", None),
 }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -121,6 +121,9 @@ It also plugs directly into scikit-learn pipelines:
    pipeline.fit(X_train, y_train)
    pipeline.predict(X_test)
 
+See more in the tutorial :ref:`tabicl_with_skrub` on how to create a pipeline
+with good parameters.
+
 For **time-series forecasting**, install the extra dependencies and use
 :class:`tabicl.TabICLForecaster`:
 

--- a/tutorials/string_handling.py
+++ b/tutorials/string_handling.py
@@ -68,7 +68,8 @@ print(f"ROC AUC without skrub: {scores.mean():.3f} (+/- {scores.std():.3f}), tim
 # The function :func:`skrub.tabular_pipeline` provides a convenient way to initialize a pipeline.
 # In addition to estimators from ``scikit-learn``, it accepts instances of type
 # :class:`tabicl.TabICLClassifier` and :class:`tabicl.TabICLRegressor` with TabICL-suitable defaults for
-# :class:`skrub.TableVectorizer` as the first step. Here is a short example on how to use it:
+# :class:`skrub.TableVectorizer` as the first step and the estimator itself as the second step.
+# Here is a short example on how to use it:
 #
 # .. code-block:: python
 #

--- a/tutorials/string_handling.py
+++ b/tutorials/string_handling.py
@@ -90,12 +90,7 @@ print(f"ROC AUC without skrub: {scores.mean():.3f} (+/- {scores.std():.3f}), tim
 # .. note::
 #    We also provide advanced settings for the DatetimeEncoder,
 #    even though our example dataset here does not contain dates. This also serves to show how to
-#    adjust parameters. In :func:`skrub.tabular_pipeline` you would get instead a TableVectorizer, with
-#
-#    - :class:`StringEncoder() <skrub._string_encoder.StringEncoder>` for high cardinality with default parameters, and
-#    - :class:`DatetimeEncoder(periodic_encoding='spline') <skrub._datetime_encoder.DatetimeEncoder>`
-#
-#    instead.
+#    adjust parameters.
 
 pipeline = make_pipeline(
     TableVectorizer(

--- a/tutorials/string_handling.py
+++ b/tutorials/string_handling.py
@@ -60,10 +60,24 @@ scores = cross_val_score(reg, X, y, cv=2, scoring="roc_auc_ovr")
 print(f"ROC AUC without skrub: {scores.mean():.3f} (+/- {scores.std():.3f}), time: {time.time()-start_time:.1f} s")
 
 # %%
+# .. _tabicl_with_skrub:
 # TabICL with skrub
 # -------------------------------------
 #
 # With skrub, we can embed high-cardinality string columns using semantics-aware methods into numerical features.
+# The function :func:`skrub.tabular_pipeline` provides a convenient way to initialize a pipeline.
+# In addition to estimators from ``scikit-learn``, it accepts instances of type
+# :class:`tabicl.TabICLClassifier` and :class:`tabicl.TabICLRegressor` with TabICL-suitable defaults for
+# :class:`skrub.TableVectorizer` as the first step. Here is a short example on how to use it:
+#
+# .. code-block:: python
+#
+#    from skrub import tabular_pipeline
+#
+#    pipeline = tabular_pipeline(TabICLClassifier())
+#
+# Let's take a look below to see how this works behind the scenes.
+#
 # The `TableVectorizer <https://skrub-data.org/stable/reference/generated/skrub.TableVectorizer.html>`_
 # applies different conversions to columns of a dataframe.
 # Here, for efficiency reasons, we use the StringEncoder with lower-dimensional embeddings
@@ -72,8 +86,16 @@ print(f"ROC AUC without skrub: {scores.mean():.3f} (+/- {scores.std():.3f}), tim
 # which then treats them as categoricals.
 # (Without "passthrough", they would be one-hot encoded by default,
 # which is not the recommended way to handle categoricals for TabICL.)
-# We also provide advanced settings for the DatetimeEncoder,
-# even though our example dataset here does not contain dates.
+#
+# .. note::
+#    We also provide advanced settings for the DatetimeEncoder,
+#    even though our example dataset here does not contain dates. This also serves to show how to
+#    adjust parameters. In :func:`skrub.tabular_pipeline` you would get instead a TableVectorizer, with
+#
+#    - :class:`StringEncoder() <skrub._string_encoder.StringEncoder>` for high cardinality with default parameters, and
+#    - :class:`DatetimeEncoder(periodic_encoding='spline') <skrub._datetime_encoder.DatetimeEncoder>`
+#
+#    instead.
 
 pipeline = make_pipeline(
     TableVectorizer(


### PR DESCRIPTION
See https://github.com/skrub-data/skrub/pull/2222

I tried to adapt existing example code in the tutorial. I also took the liberty in 30bea6e914b2cd3354eaa358aceb489accf82449 to link from quick start, but can be reverted if it is too much.

ping: @jeromedockes and @dholzmueller 