### PR TITLE
Fix UnicodeEncodeError in fine-tuning tutorials on Windows

### DIFF
--- a/tutorials/finetune_classifier.py
+++ b/tutorials/finetune_classifier.py
@@ -142,10 +142,6 @@ ft_proba = clf.predict_proba(X_test)
 ft_auc, ft_ll, ft_acc = _metrics(ft_proba, y_test)
 
 if is_main_process:
-    # Keep this table ASCII-only: it is printed to the console, and the
-    # legacy Windows code page (cp1252) cannot encode "Δ"/"↑"/"↓", which
-    # would raise UnicodeEncodeError. Non-ASCII is fine in the figures below,
-    # since Matplotlib renders text itself.
     header = f"{'metric':<12}{'pretrained':>14}{'fine-tuned':>14}{'delta':>14}"
     rule = "=" * len(header)
     print()

--- a/tutorials/finetune_classifier.py
+++ b/tutorials/finetune_classifier.py
@@ -142,7 +142,11 @@ ft_proba = clf.predict_proba(X_test)
 ft_auc, ft_ll, ft_acc = _metrics(ft_proba, y_test)
 
 if is_main_process:
-    header = f"{'metric':<12}{'pretrained':>14}{'fine-tuned':>14}{'Δ':>14}"
+    # Keep this table ASCII-only: it is printed to the console, and the
+    # legacy Windows code page (cp1252) cannot encode "Δ"/"↑"/"↓", which
+    # would raise UnicodeEncodeError. Non-ASCII is fine in the figures below,
+    # since Matplotlib renders text itself.
+    header = f"{'metric':<12}{'pretrained':>14}{'fine-tuned':>14}{'delta':>14}"
     rule = "=" * len(header)
     print()
     print(rule)
@@ -150,10 +154,11 @@ if is_main_process:
     print(rule)
     print(header)
     print("-" * len(header))
-    print(f"{'ROC-AUC ↑':<12}{base_auc:>14.4f}{ft_auc:>14.4f}{ft_auc - base_auc:>+14.4f}")
-    print(f"{'log-loss ↓':<12}{base_ll:>14.4f}{ft_ll:>14.4f}{ft_ll - base_ll:>+14.4f}")
-    print(f"{'accuracy ↑':<12}{base_acc:>14.4f}{ft_acc:>14.4f}{ft_acc - base_acc:>+14.4f}")
+    print(f"{'ROC-AUC':<12}{base_auc:>14.4f}{ft_auc:>14.4f}{ft_auc - base_auc:>+14.4f}")
+    print(f"{'log-loss':<12}{base_ll:>14.4f}{ft_ll:>14.4f}{ft_ll - base_ll:>+14.4f}")
+    print(f"{'accuracy':<12}{base_acc:>14.4f}{ft_acc:>14.4f}{ft_acc - base_acc:>+14.4f}")
     print(rule)
+    print("higher is better: ROC-AUC, accuracy;  lower is better: log-loss")
 
 # %%
 # Figure 1 — Decision boundaries + probability contours

--- a/tutorials/finetune_regressor.py
+++ b/tutorials/finetune_regressor.py
@@ -126,10 +126,6 @@ ft_pred = reg.predict(X_test)
 ft_mse, ft_mae, ft_r2 = _metrics(ft_pred, y_test)
 
 if is_main_process:
-    # Keep this table ASCII-only: it is printed to the console, and the
-    # legacy Windows code page (cp1252) cannot encode "Δ"/"↑"/"↓", which
-    # would raise UnicodeEncodeError. Non-ASCII is fine in the figures below,
-    # since Matplotlib renders text itself.
     header = f"{'metric':<10}{'pretrained':>14}{'fine-tuned':>14}{'delta':>14}"
     rule = "=" * len(header)
     print()

--- a/tutorials/finetune_regressor.py
+++ b/tutorials/finetune_regressor.py
@@ -126,7 +126,11 @@ ft_pred = reg.predict(X_test)
 ft_mse, ft_mae, ft_r2 = _metrics(ft_pred, y_test)
 
 if is_main_process:
-    header = f"{'metric':<10}{'pretrained':>14}{'fine-tuned':>14}{'Δ':>14}"
+    # Keep this table ASCII-only: it is printed to the console, and the
+    # legacy Windows code page (cp1252) cannot encode "Δ"/"↑"/"↓", which
+    # would raise UnicodeEncodeError. Non-ASCII is fine in the figures below,
+    # since Matplotlib renders text itself.
+    header = f"{'metric':<10}{'pretrained':>14}{'fine-tuned':>14}{'delta':>14}"
     rule = "=" * len(header)
     print()
     print(rule)
@@ -134,10 +138,11 @@ if is_main_process:
     print(rule)
     print(header)
     print("-" * len(header))
-    print(f"{'MSE ↓':<10}{base_mse:>14.4f}{ft_mse:>14.4f}{ft_mse - base_mse:>+14.4f}")
-    print(f"{'MAE ↓':<10}{base_mae:>14.4f}{ft_mae:>14.4f}{ft_mae - base_mae:>+14.4f}")
-    print(f"{'R² ↑':<10}{base_r2:>14.4f}{ft_r2:>14.4f}{ft_r2 - base_r2:>+14.4f}")
+    print(f"{'MSE':<10}{base_mse:>14.4f}{ft_mse:>14.4f}{ft_mse - base_mse:>+14.4f}")
+    print(f"{'MAE':<10}{base_mae:>14.4f}{ft_mae:>14.4f}{ft_mae - base_mae:>+14.4f}")
+    print(f"{'R2':<10}{base_r2:>14.4f}{ft_r2:>14.4f}{ft_r2 - base_r2:>+14.4f}")
     print(rule)
+    print("lower is better: MSE, MAE;  higher is better: R2")
 
 # %%
 # Figure 1 — Predictions + residuals


### PR DESCRIPTION
## Problem

Both fine-tuning tutorials crash on Windows. Training completes fine, then the script dies while printing the results table:

```
File "tutorials/finetune_regressor.py", line 135, in <module>
    print(header)
UnicodeEncodeError: 'charmap' codec can't encode character '\u0394' in position 51: character maps to <undefined>
```

On Windows `sys.stdout` defaults to the legacy code page (cp1252), which cannot encode `U+0394` (Δ), `U+2191` (↑) or `U+2193` (↓).

The crash lands *after* `fit()` but *before* the figures are drawn, so all fine-tuning work is lost and neither figure is produced — the tutorial appears to fail entirely despite the model having trained successfully.

Affects `tutorials/finetune_classifier.py` and `tutorials/finetune_regressor.py`. The other six tutorials are unaffected: they print pure ASCII, except `getting_started.py`, whose `R²` happens to be encodable in cp1252.

## Fix

Restrict the printed table to ASCII: `Δ` → `delta`, and the per-metric `↑`/`↓` arrows are replaced by a single legend line stating the direction of improvement.

Non-ASCII elsewhere in these files is deliberately left alone — axis labels, titles and `metric_names` only ever reach Matplotlib, which renders text itself and is unaffected by the console code page.

## Verification

Run on Windows 11, `sys.stdout.encoding == 'cp1252'`, no `PYTHONIOENCODING` override. Before this change both tutorials raised `UnicodeEncodeError`; after it, both run to completion and emit both figures:

```
======================================================
Test-set metrics  (n_train=80, n_test=1220)
======================================================
metric          pretrained    fine-tuned         delta
------------------------------------------------------
ROC-AUC             0.9790        0.9906       +0.0116
log-loss            0.1880        0.1238       -0.0642
accuracy            0.9057        0.9410       +0.0352
======================================================
higher is better: ROC-AUC, accuracy;  lower is better: log-loss
```

```
====================================================
Test-set metrics  (n_train=40, n_test=760)
====================================================
metric        pretrained    fine-tuned         delta
----------------------------------------------------
MSE               0.0573        0.0240       -0.0333
MAE               0.1543        0.1060       -0.0482
R2                0.8894        0.9537       +0.0643
====================================================
lower is better: MSE, MAE;  higher is better: R2
```

CI does not catch this because the runners use UTF-8 stdout, and the tutorials are not executed as tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)