### PR TITLE
Fix: isnan/isfinite

### DIFF
--- a/src/tabicl/prior/_mlp_scm.py
+++ b/src/tabicl/prior/_mlp_scm.py
@@ -255,8 +255,8 @@ class MLPSCM(nn.Module):
         # Handle outputs based on causality
         X, y = self.handle_outputs(causes, outputs)
 
-        # Check for NaNs and handle them by setting to default values
-        if torch.any(torch.isnan(X)) or torch.any(torch.isnan(y)):
+        # Check for NaNs/Infs and handle them by setting to default values
+        if not torch.isfinite(X).all() or not torch.isfinite(y).all():
             X[:] = 0.0
             y[:] = -100.0
 

--- a/src/tabicl/prior/_tree_scm.py
+++ b/src/tabicl/prior/_tree_scm.py
@@ -309,8 +309,8 @@ class TreeSCM(nn.Module):
         # Handle outputs based on causality
         X, y = self.handle_outputs(causes, outputs)
 
-        # Check for NaNs and handle them by setting to default values
-        if torch.any(torch.isnan(X)) or torch.any(torch.isnan(y)):
+        # Check for NaNs/Infs and handle them by setting to default values
+        if not torch.isfinite(X).all() or not torch.isfinite(y).all():
             X[:] = 0.0
             y[:] = -100.0
 


### PR DESCRIPTION
I think this fixes a probable bug where invalid (`inf`) values could enter the generation procedure.
Example to generate about 1024 `inf` datasets:

```python
import torch, numpy as np
from tabicl.prior import PriorDataset
from tabicl.prior._mlp_scm import MLPSCM
from tabicl.prior._tree_scm import TreeSCM

N = 100_000  # num draws

def _f(self):  # same code as forward in the prior package
    causes = self.xsampler.sample()  # (seq_len, num_causes)
    outputs = [causes]
    for layer in self.layers:
        outputs.append(layer(outputs[-1]))
    outputs = outputs[2:]  # Start from 2 because the first layer is only linear without activation
    X, y = self.handle_outputs(causes, outputs)

    # HERE we introduced the change
    if torch.any(torch.isnan(X)) or torch.any(torch.isnan(y)):
        X[:] = 0.0
        y[:] = -100.0

    if self.num_outputs == 1:
        y = y.squeeze(-1)
    return X, y


# monkeypatched for easy check
MLPSCM.forward = _f
TreeSCM.forward = _f

np.random.seed(0); torch.manual_seed(0)
prior = PriorDataset(
    regression=True, batch_size=8, batch_size_per_gp=8,
    batch_size_per_subgp=8, min_features=2, max_features=64,
    max_seq_len=1024, min_train_size=0.25, max_train_size=0.9,
    prior_type="mlp_scm", device="cpu", n_jobs=1)

for i, batch in enumerate(prior):
    print(f"\r{i}", end="", flush=True)
    if i >= N: break
    X, y, d, _, _ = batch
    if not torch.isfinite(y).all():
        n_inf = (~torch.isfinite(y)).sum().item()
        bad_tables = (~torch.isfinite(y)).any(1)
        print(f"{i=}: {n_inf=}")
        for t in range(len(y)):
            if not torch.isfinite(y[t]).all():
                n_nan = torch.isnan(y[t]).sum().item()
                n_inf = torch.isinf(y[t]).sum().item()
                print(f"{t=}: {n_nan=}, {n_inf=}, {y.shape[1]=}")
        break
```