### PR TITLE
Respect cgroup memory limits when detecting available CPU memory

### DIFF
--- a/src/tabicl/_model/inference.py
+++ b/src/tabicl/_model/inference.py
@@ -4,6 +4,7 @@ import os
 import uuid
 import math
 import shutil
+import pathlib
 import psutil
 import weakref
 import itertools
@@ -20,6 +21,37 @@ from torch import Tensor
 
 from .kv_cache import KVCache
 from .attention import flash_attn3_toggle
+
+
+def _cgroup_memory_headroom() -> int | None:
+    """Bytes this process may still allocate under its cgroup, or None if unlimited.
+
+    Handles cgroup v2 (``memory.max`` / ``memory.current``) and v1
+    (``memory.limit_in_bytes`` / ``memory.usage_in_bytes``). Returns None when there is
+    no cgroup, when the limit is literally ``"max"``, or when it is the sentinel huge
+    value v1 uses to mean unlimited -- in all of which cases psutil's figure stands.
+
+    Never raises: a memory estimate is not worth crashing an inference call over, and
+    every failure path here simply falls back to the previous behaviour.
+    """
+    pairs = (("/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory.current"),
+             ("/sys/fs/cgroup/memory/memory.limit_in_bytes",
+              "/sys/fs/cgroup/memory/memory.usage_in_bytes"))
+    for limit_path, usage_path in pairs:
+        try:
+            limit_raw = pathlib.Path(limit_path).read_text().split()[0]
+            if limit_raw == "max":
+                return None
+            limit = int(limit_raw)
+            # v1 signals "unlimited" with a value near 2**63; anything at or above the
+            # host's physical memory is not a real constraint either.
+            if limit >= psutil.virtual_memory().total:
+                return None
+            usage = int(pathlib.Path(usage_path).read_text().split()[0])
+            return max(0, limit - usage)
+        except (OSError, ValueError, IndexError):
+            continue
+    return None
 
 
 class MemoryEstimator:
@@ -754,15 +786,37 @@ class InferenceManager:
         raise ValueError(f"Invalid offload={offload!r}. Expected bool or one of 'auto', 'gpu', 'cpu', 'disk'.")
 
     def get_available_cpu_memory(self) -> float:
-        """Get available CPU memory in MB.
+        """Get available CPU memory in MB, respecting any cgroup limit.
 
         Returns
         -------
         float
             Available CPU memory in megabytes. This is the amount of memory
-            that can be allocated without causing swap.
+            that can be allocated without causing swap -- or, inside a
+            memory-limited container, without being killed.
+
+        Notes
+        -----
+        ``psutil.virtual_memory().available`` reports the **host's** free memory and is
+        blind to cgroup limits, so inside a memory-limited container (Docker, Kubernetes,
+        most GPU clouds) it can substantially overstate what this process may actually
+        allocate. Measured on one such container: psutil reported **450.8 GB available**
+        against a real headroom of **102.4 GB**, an overestimate of 4.4x.
+
+        This value feeds ``_resolve_offload_mode``, which decides whether ``offload="auto"``
+        keeps outputs in CPU memory or escalates to disk. Overestimating it means never
+        escalating, and the resulting failure is unusually hard to diagnose: the cgroup OOM
+        killer sends SIGKILL, so the process dies with **no Python traceback and no CUDA
+        error**, which from the outside is indistinguishable from a clean exit.
+
+        The cgroup headroom is intersected with psutil's figure rather than replacing it,
+        so this can only ever be more conservative than the previous behaviour.
         """
-        return psutil.virtual_memory().available / (1024 * 1024)
+        available = psutil.virtual_memory().available
+        headroom = _cgroup_memory_headroom()
+        if headroom is not None:
+            available = min(available, headroom)
+        return available / (1024 * 1024)
 
     def get_available_gpu_memory(self) -> float:
         """Get available GPU memory in MB.

--- a/src/tabicl/_model/inference.py
+++ b/src/tabicl/_model/inference.py
@@ -32,7 +32,7 @@ def _cgroup_memory_headroom() -> int | None:
     value v1 uses to mean unlimited -- in all of which cases psutil's figure stands.
 
     Never raises: a memory estimate is not worth crashing an inference call over, and
-    every failure path here simply falls back to the previous behaviour.
+    every failure path here simply falls back to the unconstrained behavior.
     """
     pairs = (("/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory.current"),
              ("/sys/fs/cgroup/memory/memory.limit_in_bytes",
@@ -810,7 +810,9 @@ class InferenceManager:
         error**, which from the outside is indistinguishable from a clean exit.
 
         The cgroup headroom is intersected with psutil's figure rather than replacing it,
-        so this can only ever be more conservative than the previous behaviour.
+        Under the hood, this methods intersects the value returned
+        by ``psutil.virtual_memory().available`` with cgroup
+        memory constraints for the current process, if any.
         """
         available = psutil.virtual_memory().available
         headroom = _cgroup_memory_headroom()

--- a/tests/test_inference_memory.py
+++ b/tests/test_inference_memory.py
@@ -1,0 +1,80 @@
+"""Available-CPU-memory detection must respect cgroup limits.
+
+``psutil.virtual_memory().available`` reports the host's free memory and is blind to
+cgroup limits, so inside a memory-limited container it overstates what the process may
+allocate. That figure feeds ``_resolve_offload_mode``, so overestimating it means
+``offload="auto"`` never escalates from CPU to disk -- and the resulting cgroup OOM kill
+arrives as SIGKILL, with no Python traceback and no CUDA error.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import psutil
+import pytest
+
+from tabicl._model.inference import InferenceManager, _cgroup_memory_headroom
+
+
+def test_headroom_is_none_when_there_is_no_cgroup(monkeypatch):
+    def missing(self, *a, **k):
+        raise FileNotFoundError(str(self))
+
+    monkeypatch.setattr(pathlib.Path, "read_text", missing)
+    assert _cgroup_memory_headroom() is None
+
+
+def test_headroom_is_limit_minus_usage(monkeypatch):
+    # Values deliberately below any plausible host RAM: a limit at or above physical
+    # memory is treated as "no real constraint", which is how cgroup v1's unlimited
+    # sentinel is caught, so a larger fixture would be discarded and assert nothing.
+    def fake(self, *a, **k):
+        name = str(self)
+        if name.endswith(("memory.max", "memory.limit_in_bytes")):
+            return "8000000000"
+        if name.endswith(("memory.current", "memory.usage_in_bytes")):
+            return "1000000000"
+        raise FileNotFoundError(name)
+
+    monkeypatch.setattr(pathlib.Path, "read_text", fake)
+    assert _cgroup_memory_headroom() == 7_000_000_000
+
+
+def test_cgroup_v2_max_means_unlimited(monkeypatch):
+    monkeypatch.setattr(pathlib.Path, "read_text", lambda self, *a, **k: "max")
+    assert _cgroup_memory_headroom() is None
+
+
+def test_cgroup_v1_unlimited_sentinel_is_not_a_limit(monkeypatch):
+    # v1 signals "unlimited" with a value near 2**63. Treating it as a real limit would
+    # make every uncontained run believe it had exabytes of headroom.
+    monkeypatch.setattr(pathlib.Path, "read_text",
+                        lambda self, *a, **k: "9223372036854771712")
+    assert _cgroup_memory_headroom() is None
+
+
+def test_detection_never_raises(monkeypatch):
+    # A memory estimate is not worth failing an inference call over; every error path
+    # must fall back to the previous behaviour.
+    def boom(self, *a, **k):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(pathlib.Path, "read_text", boom)
+    assert _cgroup_memory_headroom() is None
+
+
+def test_available_memory_is_the_minimum_of_psutil_and_cgroup(monkeypatch):
+    from tabicl._model import inference
+
+    mgr = InferenceManager.__new__(InferenceManager)
+
+    # Under a cgroup cap, the cap wins.
+    monkeypatch.setattr(inference, "_cgroup_memory_headroom", lambda: 1024 ** 3)
+    assert InferenceManager.get_available_cpu_memory(mgr) == pytest.approx(1024.0)
+
+    # Without one, behaviour is exactly as before -- this change can only shrink the
+    # estimate, never grow it.
+    monkeypatch.setattr(inference, "_cgroup_memory_headroom", lambda: None)
+    assert InferenceManager.get_available_cpu_memory(mgr) == pytest.approx(
+        psutil.virtual_memory().available / 1024 ** 2, rel=0.2)


### PR DESCRIPTION
## The problem

`InferenceManager.get_available_cpu_memory()` returns `psutil.virtual_memory().available`, which reports the **host's** free memory and is blind to cgroup limits. Inside a memory-limited container — Docker, Kubernetes, most GPU clouds — it can substantially overstate what the process may actually allocate.

Measured on the container where I hit this:

| | |
|---|---:|
| `psutil.virtual_memory().available` | **450.8 GB** |
| cgroup limit | 116.4 GB |
| cgroup already used | 14.0 GB |
| **real headroom** | **102.4 GB** |

A 4.4× overestimate. `free` reports the same host figure, which is why this is easy to misdiagnose from inside the container.

## Why it matters

That value feeds `_resolve_offload_mode(output_mb, gpu_mem, cpu_free, disk_free)`, which decides whether `offload="auto"` keeps outputs in CPU memory or escalates to disk. Believing it has 450 GB, it never escalates.

The resulting failure is unusually hard to diagnose: the cgroup OOM killer sends **SIGKILL**, so the process dies with **no Python traceback and no CUDA error**. From the outside it is indistinguishable from a clean exit — the script simply moves on to the next thing.

In my case it cost two multi-hour runs before I attributed it. Both completed an *entire* validation sweep and died at the first larger prediction, which is what finally gave it away: the same process, the same task, minutes apart, with the GPU holding 1 MiB at the moment of death. It was never VRAM.

## The fix

Intersect the cgroup headroom with psutil's figure rather than replacing it:

```python
available = psutil.virtual_memory().available
headroom = _cgroup_memory_headroom()
if headroom is not None:
    available = min(available, headroom)
```

So the estimate can **only ever become more conservative**. On a host without a cgroup limit the returned value is unchanged.

`_cgroup_memory_headroom()`:

- handles cgroup **v2** (`memory.max` / `memory.current`) and **v1** (`memory.limit_in_bytes` / `memory.usage_in_bytes`)
- returns `None` for v2's literal `"max"`, for v1's ~2**63 "unlimited" sentinel, and for any limit at or above physical memory
- **never raises** — a memory estimate is not worth failing an inference call over, so every error path falls back to the previous behaviour

## Tests

Six in `tests/test_inference_memory.py`: no cgroup present, limit-minus-usage, both unlimited sentinels, permission errors, and one pinning that the returned value can only shrink relative to psutil's.

## Scope — what this does not fix

This corrects the *detection*; it does not make every workload fit. After this change one of my tasks (≈255k inference rows × 342 features) still OOMs even with `offload="disk"`, and one that previously died now completes. I mention it so the change is not read as a general fix for large-input OOMs.

Happy to adjust naming, placement, or the cgroup-reading approach if you'd prefer it structured differently.
