### PR TITLE
CI: check if torch nightly fixes MPS F.linear #192934

### DIFF
--- a/.github/workflows/mps-linear-192934.yml
+++ b/.github/workflows/mps-linear-192934.yml
@@ -1,0 +1,66 @@
+name: 'mps-linear-192934'
+
+# Draft CI probe: does pytorch nightly (post #189496) also fix #192934 on
+# GitHub Actions VirtualMac / Apple M1? See scripts/check_mps_linear_192934.py.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - check-mps-nightly-192934
+
+jobs:
+  check:
+    name: macos / torch-${{ matrix.torch-channel }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Stable documents the current VirtualMac failure (#192934).
+        # Nightly asks whether the #189496 flatten workaround covers it.
+        torch-channel: [stable, nightly]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.5.4"
+      - name: Install PyTorch (${{ matrix.torch-channel }})
+        shell: bash
+        run: |
+          if [ "${{ matrix.torch-channel }}" = "nightly" ]; then
+            uv pip install --system --pre --upgrade \
+              --index-url https://download.pytorch.org/whl/nightly/cpu \
+              torch
+          else
+            uv pip install --system --upgrade torch
+          fi
+          python -c "import torch; print(torch.__version__)"
+      - name: Run #192934 F.linear MPS repro
+        id: repro
+        # Stable is expected to FAIL on VirtualMac today; nightly is the question.
+        continue-on-error: ${{ matrix.torch-channel == 'stable' }}
+        run: python scripts/check_mps_linear_192934.py
+      - name: Job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## torch-${{ matrix.torch-channel }}"
+            echo ""
+            echo "- version: \`$(python -c 'import torch; print(torch.__version__)')\`"
+            echo "- repro step outcome: \`${{ steps.repro.outcome }}\`"
+            if [ "${{ matrix.torch-channel }}" = "stable" ]; then
+              echo "- note: failure is currently expected on GHA VirtualMac (pytorch#192934)"
+            else
+              echo "- note: success means nightly (post #189496) also fixes #192934 here"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/check_mps_linear_192934.py
+++ b/scripts/check_mps_linear_192934.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""Check pytorch/pytorch#192934: F.linear+bias on 3D input vs CPU on MPS.
+
+Reproducer from https://github.com/pytorch/pytorch/issues/192934 (VirtualMac /
+Apple M1 on GitHub Actions). Related to the large-batch fix in #189495 / #189496:
+this script asks whether a post-fix nightly also clears the small-shape
+VirtualMac failure.
+
+Exit codes:
+  0  MPS unavailable (skipped) or all checks within tolerance
+  1  at least one check exceeded tolerance
+"""
+
+from __future__ import annotations
+
+import platform
+import subprocess
+import sys
+
+
+def _sysctl(name: str) -> str:
+    try:
+        return subprocess.check_output(
+            ["sysctl", "-n", name], text=True, stderr=subprocess.DEVNULL, timeout=10
+        ).strip()
+    except Exception:  # noqa: BLE001
+        return "<unavailable>"
+
+
+def main() -> int:
+    import torch
+    import torch.nn.functional as F
+
+    print(f"python:  {sys.version.split()[0]}")
+    print(f"platform:{platform.platform()}")
+    print(f"torch:   {torch.__version__}")
+    if sys.platform == "darwin":
+        print(f"cpu:     {_sysctl('machdep.cpu.brand_string')}")
+        print(f"model:   {_sysctl('hw.model')}")
+    print(f"mps.built:{torch.backends.mps.is_built()}")
+    print(f"mps.avail:{torch.backends.mps.is_available()}")
+
+    if not torch.backends.mps.is_available():
+        print("SKIP: MPS not available on this runner")
+        return 0
+
+    torch.manual_seed(0)
+    x = torch.randn(2, 64, 128)
+    w = torch.randn(384, 128)
+    b = torch.randn(384)
+
+    y_cpu = F.linear(x, w, b)
+    y_mps = F.linear(x.to("mps"), w.to("mps"), b.to("mps")).cpu()
+    y_mm = (x.to("mps") @ w.to("mps").T + b.to("mps")).cpu()
+    y_nb = F.linear(x.to("mps"), w.to("mps"), None).cpu()
+    torch.mps.synchronize()
+
+    # Same seed tensors for the bias-free CPU reference.
+    y_nb_cpu = x @ w.T
+
+    checks = [
+        ("F.linear+bias 3D (issue #192934)", (y_cpu - y_mps).abs().max().item(), 1e-2),
+        ("matmul+bias 3D (control)", (y_cpu - y_mm).abs().max().item(), 1e-2),
+        ("F.linear bias=None 3D (control)", (y_nb_cpu - y_nb).abs().max().item(), 1e-2),
+    ]
+
+    failed = False
+    print()
+    for name, diff, tol in checks:
+        status = "OK" if diff < tol else "FAIL"
+        if status == "FAIL":
+            failed = True
+        print(f"{status:4}  {name}: max_abs={diff:.6g} (tol={tol:g})")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds a minimal VirtualMac MPS repro for [pytorch/pytorch#192934](https://github.com/pytorch/pytorch/issues/192934) (`F.linear` + bias on 3D input).
- Runs it on `macos-latest` against both **stable** and **nightly** PyTorch to see whether the [#189496](https://github.com/pytorch/pytorch/pull/189496) nightly workaround (fix for [#189495](https://github.com/pytorch/pytorch/issues/189495)) also clears this smaller-shape failure.
- Stable is allowed to fail (`continue-on-error`) because that documents the current bug; nightly failure means the issue is still open on post-fix builds.

## Test plan
- [ ] Wait for `mps-linear-192934` workflow on this PR
- [ ] Confirm `torch-stable` fails (or soft-fails) with large `max_abs` on `F.linear+bias 3D`
- [ ] Confirm `torch-nightly` outcome: pass ⇒ nightly fixes #192934 on GHA; fail ⇒ distinct/unfixed bug


Made with [Cursor](https://cursor.com)