### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,4 +444,4 @@ please cite our papers for **[TabICL](https://arxiv.org/abs/2502.05564)** and **
 
 ## Star history
 
-[![Star History Chart](https://api.star-history.com/svg?repos=soda-inria/tabicl&type=date&legend=top-left)](https://www.star-history.com/#soda-inria/tabicl&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=soda-inria/tabicl&type=date&legend=top-left)](https://star-history.dera.page/#soda-inria/tabicl&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This updates it to a working alternative so the chart renders correctly again.