### PR TITLE
Keep one constant feature so all-constant X fits instead of raising

### DIFF
--- a/src/tabicl/_sklearn/preprocessing.py
+++ b/src/tabicl/_sklearn/preprocessing.py
@@ -208,6 +208,8 @@ class UniqueFeatureFilter(TransformerMixin, BaseEstimator):
 
        - With few samples, it's difficult to reliably assess feature variability.
        - A feature might appear constant in few samples but vary in the complete dataset.
+    3. If every feature would be removed, the first one is kept so that the output
+       always has at least one column.
     """
 
     def __init__(self, threshold: int = 1):
@@ -239,6 +241,13 @@ class UniqueFeatureFilter(TransformerMixin, BaseEstimator):
             self.features_to_keep_ = np.array(
                 [len(np.unique(X[:, i])) > self.threshold for i in range(self.n_features_in_)]
             )
+
+            # Every feature is constant. Dropping all of them leaves a zero-column
+            # matrix that downstream steps cannot handle, so keep the first one: the
+            # model then sees a single uninformative feature and falls back to the
+            # marginal distribution of the target.
+            if not self.features_to_keep_.any():
+                self.features_to_keep_[0] = True
 
         self.n_features_out_ = np.sum(self.features_to_keep_)
 

--- a/tests/test_numpy_inputs.py
+++ b/tests/test_numpy_inputs.py
@@ -10,6 +10,7 @@ from sklearn.model_selection import train_test_split
 
 from tabicl import TabICLClassifier, TabICLRegressor
 from tabicl._model.inference import InferenceManager
+from tabicl._sklearn.preprocessing import UniqueFeatureFilter
 from tabicl._torch_devices import (
     MPS_NUMERICS_ISSUE_URL,
     resolve_default_device,
@@ -383,3 +384,18 @@ def test_tabicl_classifier_device_cpu_logloss_parity(device, kv_cache, use_amp):
 
     assert abs(scores["cpu"] - scores[device]) < score_tol
     np.testing.assert_allclose(probas["cpu"], probas[device], rtol=rtol, atol=atol)
+
+
+def test_tabicl_fits_all_constant_features():
+    """No feature is informative: one column is kept, so fit falls back to the marginal."""
+
+    X = np.tile(np.array([0.4, 1.0, 0.5, 118.2]), (6, 1))
+    y = np.array([-3.2, -1.0, 0.5, 2.0, -0.7, 1.1])
+
+    # Constant features are still dropped as long as one informative feature remains.
+    assert UniqueFeatureFilter().fit_transform(np.c_[np.ones(6), y]).shape == (6, 1)
+
+    y_pred = TabICLRegressor(n_estimators=4, random_state=0).fit(X, y).predict(X)
+
+    assert np.allclose(y_pred, y_pred[0])
+    assert abs(y_pred[0] - y.mean()) < y.std()


### PR DESCRIPTION
## Problem

When every feature in `X` is constant, `fit` fails with an opaque error from an internal recursion helper:

```
IndexError: Cannot choose from an empty sequence
```

Constant columns are dropped by `UniqueFeatureFilter`, so when *all* of them are constant the matrix reaches `Shuffler` with `n_features_in_ = 0`. `_latin_squares` → `_rls` handles `n == 1` but not `n == 0`, and bottoms out in `random.choice` on an empty list.

Repro:

```python
import numpy as np
from tabicl import TabICLRegressor

X = np.array([[0.4, 1.0, 0.5, 118.2],
              [0.4, 1.0, 0.5, 118.2]])   # every column constant
y = np.array([-3.2, -1.0])

TabICLRegressor(n_estimators=4, random_state=0).fit(X, y)
```

## Behaviour

`UniqueFeatureFilter` keeps the first feature when every one of them would be removed, so `n_features_in_` is never 0. Constant features are still dropped whenever at least one informative feature remains; only the all-constant case is affected.

The model then sees a single uninformative column and falls back to the marginal distribution of the target, as sklearn estimators do in this situation:

```python
X = np.tile(np.array([0.4, 1.0, 0.5, 118.2]), (6, 1))
y = np.array([-3.2, -1.0, 0.5, 2.0, -0.7, 1.1])

TabICLRegressor(n_estimators=4, random_state=0).fit(X, y).predict(X)
# array([-0.1974, -0.1974, ...])   y.mean() = -0.2167

TabICLClassifier(n_estimators=4, random_state=0).fit(X, [0,1,0,1,1,0]).predict_proba(X)
# array([[0.5, 0.5], ...])         the base rate
```

Every stage downstream tolerates zero variance already: `CustomStandardScaler` adds `epsilon` to the standard deviation and `OutlierRemover` floors it at `1e-6`, so the kept column reaches the model as a constant token — exactly `0.0` for both `norm_method='none'` and `'power'`, with no warnings.

## Tests

One test: all-constant `X` fits and returns the marginal, and constant features are still dropped when an informative one remains.

`tests/test_numpy_inputs.py tests/test_sklearn.py` → 280 passed, 244 skipped (skips are cuda/xpu/mps).

## Note

With a constant training column, a *test* row carrying a different constant maps to a large z-score before clipping (the scaler divides by `1e-6`), so predictions sit near the training marginal rather than pinned to it — `-0.197` at the training value, `-1.012` at `-500`, against `y.mean() = -0.217` and `y.std() = 1.70`. Pinning it exactly would mean zeroing the kept column outright, which seemed like extra machinery for a case where the answer carries no information — happy to add it if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6gTqr3M2JWnDZCNG9hVfg
