### PR TITLE
Keep reserved column slots at skip_value when target_aware=True

### DIFF
--- a/src/tabicl/_model/embedding.py
+++ b/src/tabicl/_model/embedding.py
@@ -376,6 +376,9 @@ class ColEmbedding(nn.Module):
         else:
             assert y_train is not None, "y_train must be provided when target_aware=True."
 
+            # Reserved (all-skip_value) slots must stay exactly skip_value so InducedSelfAttentionBlock can skip them.
+            skip_mask = (src == self.in_linear.skip_value).all(dim=(-2, -1))[..., None, None]  # (..., 1, 1)
+
             # Determine if mixed-radix ensemble is needed
             num_classes = int(y_train.max().item()) + 1
             needs_mixed_radix = self.max_classes > 0 and num_classes > self.max_classes
@@ -386,7 +389,7 @@ class ColEmbedding(nn.Module):
                     y_emb = self.y_encoder(y_train.float())
                 else:
                     y_emb = self.y_encoder(y_train.unsqueeze(-1))
-                src[..., :train_size, :] = src[..., :train_size, :] + y_emb
+                src[..., :train_size, :] = src[..., :train_size, :] + y_emb.masked_fill(skip_mask, 0.0)
                 src = self.tf_col(src, train_size=None if embed_with_test else train_size)
             else:
                 # Mixed-radix ensembling for many-class classification
@@ -406,7 +409,7 @@ class ColEmbedding(nn.Module):
                 for digit_idx in range(num_digits):
                     y_digit = self._extract_mixed_radix_digit(y_train, digit_idx, bases)
                     y_emb = self.y_encoder(y_digit.float())
-                    src_with_y[..., :train_size, :] = src[..., :train_size, :] + y_emb
+                    src_with_y[..., :train_size, :] = src[..., :train_size, :] + y_emb.masked_fill(skip_mask, 0.0)
                     src_accum = src_accum + self.tf_col(src_with_y, train_size=None if embed_with_test else train_size)
 
                 src = src_accum / num_digits


### PR DESCRIPTION
Fixes Issue #155.

The y embeddings are only added to columns that are not indicated as skippable with skip_value.

---

## Verifications by Claude

- **Logits are bit-identical.** Released `tabicl-classifier-v2-20260212.ckpt`, `n_estimators=1`, `T=1000` tables at 5 to 50 features: `max |Δlogit| = 0.0`. Expected, since `RowInteraction` overwrites `embeddings[:, :, :num_cls]` unconditionally in both forward paths (`_model/interaction.py:201`, `:248`), so the reserved slots were being discarded anyway.
- **The fast path now fires.** Counting the ISAB calls in which `(src == skip_value).all(dim=(-2, -1))` is true: 0 of 12 as shipped, 12 of 12 with the fix, on the same runs. As shipped, the reserved slots leave the column stage as noise in the range `-100.59` to `-99.38`, not `-100.0`.
- **The invariant holds in every branch.** Reserved slots leave `ColEmbedding` as exactly `skip_value`, and feature slots never do, for all six paths through `_compute_embeddings`: not target-aware, target-aware, mixed-radix, regression, without feature grouping, and without feature grouping with `d` given. Five of those six fail without this patch.

`ColEmbedding` at the released v2 config, `T=1000`, `train_size=800`, CPU:

```
features  fired (shipped)  fired (fixed)   shipped    fixed  speedup  feature slots identical
       5              0/3            3/3    0.027s   0.018s    1.53x                     True
      10              0/3            3/3    0.041s   0.031s    1.30x                     True
      25              0/3            3/3    0.083s   0.074s    1.13x                     True
      50              0/3            3/3    0.155s   0.149s    1.04x                     True
     100              0/3            3/3    0.296s   0.293s    1.01x                     True
```

The saving is `reserve_cls_tokens / (reserve_cls_tokens + G)` of stage-one compute, since the group axis is folded into the batch: roughly 44% of the column stage on a 5-feature table and 4% on a 100-feature one. End to end that is about 1.05x to 1.1x up to 25 features and within noise beyond.

The cache path is left alone. `_compute_embeddings_with_cache` destroys the sentinel the same way, but `forward_with_cache` (`_model/layers.py:787`) keeps the batch dimensions for the cache and cannot skip, so there are no FLOPs to save there.
